### PR TITLE
Prevent exposing duplicit system metrics

### DIFF
--- a/regattaserver/rest.go
+++ b/regattaserver/rest.go
@@ -48,7 +48,7 @@ func NewRESTServer(addr string, readTimeout time.Duration) *RESTServer {
 	mux := http.NewServeMux()
 	// expose the registered metrics at `/metrics` path.
 	mux.HandleFunc("/metrics", func(resp http.ResponseWriter, req *http.Request) {
-		metrics.WritePrometheus(resp, true)
+		metrics.WritePrometheus(resp, false)
 		mfs, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
 			resp.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Turns off exposing the system metrics for VictoriaMetrics.

## Description

Both libraries Prometheus and VictoriaMetrics are responsible for the collection. Turning off exposing the system metrics for VictoriaMetrics dependency will prevent duplication of metrics on the /metrics endpoint.