### PR TITLE
feat: improve GC algorithm and add disk metrics

### DIFF
--- a/armadaserver/kv.go
+++ b/armadaserver/kv.go
@@ -3,6 +3,7 @@
 package armadaserver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +15,83 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// keyContainsNullByte reports whether a user key contains a null (0x00) byte.
+// Null bytes are forbidden because the V2 physical-key encoding uses a 0x00
+// separator between the user-key bytes and the MVCC sequence number; allowing
+// null bytes would make the physical-key prefix ambiguous and break GC range
+// deletions.
+func keyContainsNullByte(k []byte) bool {
+	return bytes.IndexByte(k, 0) >= 0
+}
+
+// rangeEndContainsNullByte is like keyContainsNullByte but allows the
+// single-byte \x00 sentinel, which is the conventional "all keys >= key"
+// wildcard for range_end fields.
+func rangeEndContainsNullByte(k []byte) bool {
+	if len(k) == 1 && k[0] == 0 {
+		return false
+	}
+	return bytes.IndexByte(k, 0) >= 0
+}
+
+// rangeKeyContainsNullByte is like keyContainsNullByte but allows the
+// single-byte \x00 sentinel as a range start key, which represents
+// "start from the beginning of the keyspace" in a range scan.
+func rangeKeyContainsNullByte(k []byte) bool {
+	if len(k) == 1 && k[0] == 0 {
+		return false
+	}
+	return bytes.IndexByte(k, 0) >= 0
+}
+
+// validateTxnKeys checks all keys embedded in a TxnRequest for null bytes.
+func validateTxnKeys(req *armadapb.TxnRequest) error {
+	for _, cmp := range req.Compare {
+		if keyContainsNullByte(cmp.Key) {
+			return status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+		}
+		if rangeEndContainsNullByte(cmp.RangeEnd) {
+			return status.Errorf(codes.InvalidArgument, "range_end must not contain null bytes")
+		}
+	}
+	for _, op := range req.Success {
+		if err := validateRequestOpKeys(op); err != nil {
+			return err
+		}
+	}
+	for _, op := range req.Failure {
+		if err := validateRequestOpKeys(op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRequestOpKeys(op *armadapb.RequestOp) error {
+	if r := op.GetRequestRange(); r != nil {
+		if rangeKeyContainsNullByte(r.Key) {
+			return status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+		}
+		if rangeEndContainsNullByte(r.RangeEnd) {
+			return status.Errorf(codes.InvalidArgument, "range_end must not contain null bytes")
+		}
+	}
+	if p := op.GetRequestPut(); p != nil {
+		if keyContainsNullByte(p.Key) {
+			return status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+		}
+	}
+	if d := op.GetRequestDeleteRange(); d != nil {
+		if keyContainsNullByte(d.Key) {
+			return status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+		}
+		if rangeEndContainsNullByte(d.RangeEnd) {
+			return status.Errorf(codes.InvalidArgument, "range_end must not contain null bytes")
+		}
+	}
+	return nil
+}
 
 // KVServer implements KV service from proto/regatta.proto.
 type KVServer struct {
@@ -43,8 +121,16 @@ func (s *KVServer) Range(ctx context.Context, req *armadapb.RangeRequest) (*arma
 		return nil, status.Error(codes.InvalidArgument, "table must be set")
 	}
 
-	if len(req.GetKey()) == 0 {
+	if len(req.GetKey()) == 0 && len(req.GetRangeEnd()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "key must be set")
+	}
+
+	if rangeKeyContainsNullByte(req.GetKey()) {
+		return nil, status.Error(codes.InvalidArgument, "key must not contain null bytes")
+	}
+
+	if rangeEndContainsNullByte(req.GetRangeEnd()) {
+		return nil, status.Error(codes.InvalidArgument, "range_end must not contain null bytes")
 	}
 
 	val, err := s.Storage.Range(ctx, req)
@@ -82,6 +168,14 @@ func (s *KVServer) IterateRange(req *armadapb.RangeRequest, srv armadapb.KV_Iter
 
 	if len(req.GetKey()) == 0 {
 		return status.Error(codes.InvalidArgument, "key must be set")
+	}
+
+	if keyContainsNullByte(req.GetKey()) {
+		return status.Error(codes.InvalidArgument, "key must not contain null bytes")
+	}
+
+	if rangeEndContainsNullByte(req.GetRangeEnd()) {
+		return status.Error(codes.InvalidArgument, "range_end must not contain null bytes")
 	}
 
 	ctx := srv.Context()
@@ -123,6 +217,10 @@ func (s *KVServer) Put(ctx context.Context, req *armadapb.PutRequest) (*armadapb
 		return nil, status.Errorf(codes.InvalidArgument, "key must be set")
 	}
 
+	if keyContainsNullByte(req.GetKey()) {
+		return nil, status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+	}
+
 	r, err := s.Storage.Put(ctx, req)
 	if err != nil {
 		if errors.Is(err, serrors.ErrTableNotFound) {
@@ -146,6 +244,14 @@ func (s *KVServer) DeleteRange(ctx context.Context, req *armadapb.DeleteRangeReq
 		return nil, status.Errorf(codes.InvalidArgument, "key must be set")
 	}
 
+	if keyContainsNullByte(req.GetKey()) {
+		return nil, status.Errorf(codes.InvalidArgument, "key must not contain null bytes")
+	}
+
+	if rangeEndContainsNullByte(req.GetRangeEnd()) {
+		return nil, status.Errorf(codes.InvalidArgument, "range_end must not contain null bytes")
+	}
+
 	r, err := s.Storage.Delete(ctx, req)
 	if err != nil {
 		if errors.Is(err, serrors.ErrTableNotFound) {
@@ -166,6 +272,10 @@ func (s *KVServer) DeleteRange(ctx context.Context, req *armadapb.DeleteRangeReq
 func (s *KVServer) Txn(ctx context.Context, req *armadapb.TxnRequest) (*armadapb.TxnResponse, error) {
 	if len(req.GetTable()) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "table must be set")
+	}
+
+	if err := validateTxnKeys(req); err != nil {
+		return nil, err
 	}
 
 	r, err := s.Storage.Txn(ctx, req)

--- a/armadaserver/kv_test.go
+++ b/armadaserver/kv_test.go
@@ -533,6 +533,100 @@ func TestKVServer_Txn(t *testing.T) {
 	r.NoError(err)
 }
 
+func TestKVServer_NullByteValidation(t *testing.T) {
+	nullKey := []byte("foo\x00bar")
+	nullRangeEnd := []byte("zoo\x00bar")
+	wildcardRangeEnd := []byte{0}
+	wantErr := status.Errorf(codes.InvalidArgument, "key must not contain null bytes").Error()
+	wantRangeEndErr := status.Errorf(codes.InvalidArgument, "range_end must not contain null bytes").Error()
+
+	storage := &mockKVService{}
+	kv := KVServer{Storage: storage}
+
+	t.Run("Range key", func(t *testing.T) {
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: nullKey})
+		require.EqualError(t, err, wantErr)
+	})
+
+	t.Run("Range range_end", func(t *testing.T) {
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: key1Name, RangeEnd: nullRangeEnd})
+		require.EqualError(t, err, wantRangeEndErr)
+	})
+
+	t.Run("Range wildcard range_end allowed", func(t *testing.T) {
+		storage.On("Range", mock.Anything, mock.Anything).Return(&armadapb.RangeResponse{}, nil).Once()
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: key1Name, RangeEnd: wildcardRangeEnd})
+		require.NoError(t, err)
+	})
+
+	t.Run("Range wildcard start key allowed", func(t *testing.T) {
+		wildcardKey := []byte{0}
+		storage.On("Range", mock.Anything, mock.Anything).Return(&armadapb.RangeResponse{}, nil).Once()
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: wildcardKey, RangeEnd: wildcardRangeEnd})
+		require.NoError(t, err)
+	})
+
+	t.Run("Range empty key with range_end allowed (scan all)", func(t *testing.T) {
+		storage.On("Range", mock.Anything, mock.Anything).Return(&armadapb.RangeResponse{}, nil).Once()
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: []byte{}, RangeEnd: wildcardRangeEnd})
+		require.NoError(t, err)
+	})
+
+	t.Run("Range empty key without range_end rejected", func(t *testing.T) {
+		_, err := kv.Range(context.Background(), &armadapb.RangeRequest{Table: table1Name, Key: []byte{}})
+		require.ErrorContains(t, err, "key must be set")
+	})
+
+	t.Run("Put key", func(t *testing.T) {
+		_, err := kv.Put(context.Background(), &armadapb.PutRequest{Table: table1Name, Key: nullKey})
+		require.EqualError(t, err, wantErr)
+	})
+
+	t.Run("DeleteRange key", func(t *testing.T) {
+		_, err := kv.DeleteRange(context.Background(), &armadapb.DeleteRangeRequest{Table: table1Name, Key: nullKey})
+		require.EqualError(t, err, wantErr)
+	})
+
+	t.Run("DeleteRange range_end", func(t *testing.T) {
+		_, err := kv.DeleteRange(context.Background(), &armadapb.DeleteRangeRequest{Table: table1Name, Key: key1Name, RangeEnd: nullRangeEnd})
+		require.EqualError(t, err, wantRangeEndErr)
+	})
+
+	t.Run("DeleteRange wildcard range_end allowed", func(t *testing.T) {
+		storage.On("Delete", mock.Anything, mock.Anything).Return(&armadapb.DeleteRangeResponse{}, nil).Once()
+		_, err := kv.DeleteRange(context.Background(), &armadapb.DeleteRangeRequest{Table: table1Name, Key: key1Name, RangeEnd: wildcardRangeEnd})
+		require.NoError(t, err)
+	})
+
+	t.Run("Txn compare key", func(t *testing.T) {
+		_, err := kv.Txn(context.Background(), &armadapb.TxnRequest{
+			Table:   table1Name,
+			Compare: []*armadapb.Compare{{Key: nullKey}},
+		})
+		require.EqualError(t, err, wantErr)
+	})
+
+	t.Run("Txn success op put key", func(t *testing.T) {
+		_, err := kv.Txn(context.Background(), &armadapb.TxnRequest{
+			Table: table1Name,
+			Success: []*armadapb.RequestOp{
+				{Request: &armadapb.RequestOp_RequestPut{RequestPut: &armadapb.RequestOp_Put{Key: nullKey}}},
+			},
+		})
+		require.EqualError(t, err, wantErr)
+	})
+
+	t.Run("Txn failure op delete range_end", func(t *testing.T) {
+		_, err := kv.Txn(context.Background(), &armadapb.TxnRequest{
+			Table: table1Name,
+			Failure: []*armadapb.RequestOp{
+				{Request: &armadapb.RequestOp_RequestDeleteRange{RequestDeleteRange: &armadapb.RequestOp_DeleteRange{Key: key1Name, RangeEnd: nullRangeEnd}}},
+			},
+		})
+		require.EqualError(t, err, wantRangeEndErr)
+	})
+}
+
 func TestForwardingKVServer_Put(t *testing.T) {
 	r := require.New(t)
 	client := &mockClient{}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,6 +15,7 @@ import (
 	rl "github.com/armadakv/armada/log"
 	"github.com/armadakv/armada/storage"
 	"github.com/cockroachdb/pebble/v2/vfs"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
@@ -113,6 +114,7 @@ func startEngine(config storage.Config) (*storage.Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create engine: %w", err)
 	}
+	prometheus.MustRegister(engine)
 	if err := engine.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start engine: %w", err)
 	}

--- a/storage/diskmetrics.go
+++ b/storage/diskmetrics.go
@@ -1,0 +1,96 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	raftDiskBytesMetricName  = "armada_storage_raft_disk_bytes"
+	walDiskBytesMetricName   = "armada_storage_wal_disk_bytes"
+	tableDiskBytesMetricName = "armada_storage_table_disk_bytes"
+)
+
+// diskMetrics is a prometheus.Collector that reports the on-disk footprint of
+// the three configurable storage directories:
+//   - NodeHostDir  – Raft log and Dragonboat metadata
+//   - WALDir       – separate WAL directory (optional; 0 when colocated)
+//   - Table.DataDir – per-table Pebble state-machine data
+//
+// Sizes are computed by walking the directory tree on every Prometheus scrape.
+// Because scrapes are infrequent (typically every 15–60 s) the walk overhead
+// is acceptable; a per-table breakdown can be added as a follow-up.
+type diskMetrics struct {
+	nodeHostDir string
+	walDir      string
+	tableDir    string
+
+	raftDesc  *prometheus.Desc
+	walDesc   *prometheus.Desc
+	tableDesc *prometheus.Desc
+}
+
+func newDiskMetrics(nodeHostDir, walDir, tableDir string) *diskMetrics {
+	return &diskMetrics{
+		nodeHostDir: nodeHostDir,
+		walDir:      walDir,
+		tableDir:    tableDir,
+		raftDesc: prometheus.NewDesc(
+			raftDiskBytesMetricName,
+			"Disk space used by the Raft log (NodeHostDir) in bytes.",
+			nil, nil,
+		),
+		walDesc: prometheus.NewDesc(
+			walDiskBytesMetricName,
+			"Disk space used by the WAL directory in bytes; 0 when WAL is colocated with the Raft log.",
+			nil, nil,
+		),
+		tableDesc: prometheus.NewDesc(
+			tableDiskBytesMetricName,
+			"Disk space used by the state-machine (Pebble) directory in bytes.",
+			nil, nil,
+		),
+	}
+}
+
+func (d *diskMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- d.raftDesc
+	ch <- d.walDesc
+	ch <- d.tableDesc
+}
+
+func (d *diskMetrics) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(d.raftDesc, prometheus.GaugeValue, float64(dirSize(d.nodeHostDir)))
+
+	walSize := 0.0
+	if d.walDir != "" && d.walDir != d.nodeHostDir {
+		walSize = float64(dirSize(d.walDir))
+	}
+	ch <- prometheus.MustNewConstMetric(d.walDesc, prometheus.GaugeValue, walSize)
+
+	ch <- prometheus.MustNewConstMetric(d.tableDesc, prometheus.GaugeValue, float64(dirSize(d.tableDir)))
+}
+
+// dirSize returns the total byte count of all regular files found recursively
+// under path. Returns 0 if the directory does not exist yet (e.g. before first
+// write) or if any entry cannot be stat'd.
+func dirSize(path string) int64 {
+	var total int64
+	_ = filepath.WalkDir(path, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries gracefully
+		}
+		if !entry.IsDir() {
+			info, err := entry.Info()
+			if err == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	return total
+}

--- a/storage/diskmetrics_test.go
+++ b/storage/diskmetrics_test.go
@@ -1,0 +1,84 @@
+// Copyright JAMF Software, LLC
+
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_dirSize(t *testing.T) {
+	t.Run("non-existent directory returns 0", func(t *testing.T) {
+		assert.Equal(t, int64(0), dirSize("/does/not/exist"))
+	})
+
+	t.Run("empty directory returns 0", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.Equal(t, int64(0), dirSize(dir))
+	})
+
+	t.Run("sums regular file sizes recursively", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), make([]byte, 100), 0o600))
+		sub := filepath.Join(dir, "sub")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(sub, "b"), make([]byte, 200), 0o600))
+
+		assert.Equal(t, int64(300), dirSize(dir))
+	})
+}
+
+func Test_diskMetrics_Collect(t *testing.T) {
+	raftDir := t.TempDir()
+	walDir := t.TempDir()
+	tableDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(raftDir, "raft.log"), make([]byte, 512), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(walDir, "wal.log"), make([]byte, 256), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(tableDir, "sst"), make([]byte, 1024), 0o600))
+
+	d := newDiskMetrics(raftDir, walDir, tableDir)
+
+	ch := make(chan prometheus.Metric, 10)
+	d.Collect(ch)
+	close(ch)
+
+	values := map[string]float64{}
+	for m := range ch {
+		var pb dto.Metric
+		require.NoError(t, m.Write(&pb))
+		values[m.Desc().String()] = pb.GetGauge().GetValue()
+	}
+
+	assert.Len(t, values, 3)
+	assert.InDelta(t, float64(512), values[d.raftDesc.String()], 0)
+	assert.InDelta(t, float64(256), values[d.walDesc.String()], 0)
+	assert.InDelta(t, float64(1024), values[d.tableDesc.String()], 0)
+}
+
+func Test_diskMetrics_Collect_walColocated(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data"), make([]byte, 128), 0o600))
+
+	d := newDiskMetrics(dir, "", dir)
+
+	ch := make(chan prometheus.Metric, 10)
+	d.Collect(ch)
+	close(ch)
+
+	var walValue float64
+	for m := range ch {
+		if m.Desc().String() == d.walDesc.String() {
+			var pb dto.Metric
+			require.NoError(t, m.Write(&pb))
+			walValue = pb.GetGauge().GetValue()
+		}
+	}
+	assert.InDelta(t, float64(0), walValue, 0, "WAL metric should be 0 when colocated")
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/armadakv/armada/storage/table"
 	"github.com/armadakv/armada/util/iterx"
 	"github.com/armadakv/armada/version"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
@@ -65,7 +66,18 @@ func New(cfg Config) (*Engine, error) {
 		},
 	)
 	e.LogReader = &logreader.Simple{LogQuerier: nh}
+	e.disk = newDiskMetrics(cfg.NodeHostDir, cfg.WALDir, cfg.Table.DataDir)
 	return e, nil
+}
+
+// Describe implements prometheus.Collector.
+func (e *Engine) Describe(ch chan<- *prometheus.Desc) {
+	e.disk.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (e *Engine) Collect(ch chan<- prometheus.Metric) {
+	e.disk.Collect(ch)
 }
 
 type Engine struct {
@@ -78,6 +90,7 @@ type Engine struct {
 	LogReader  logreader.Interface
 	Cluster    *cluster.Cluster
 	tableStore *kv.RaftStore
+	disk       *diskMetrics
 }
 
 func (e *Engine) Start() error {

--- a/storage/table/fsm/fsm.go
+++ b/storage/table/fsm/fsm.go
@@ -5,14 +5,12 @@ package fsm
 import (
 	"bytes"
 	"encoding/binary"
-	stderrors "errors"
 	"fmt"
 	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
-	"time"
 
 	"github.com/armadakv/armada/armadapb"
 	rp "github.com/armadakv/armada/pebble"
@@ -45,11 +43,6 @@ var (
 		KeyType: key.TypeUser,
 		Key:     key.LatestMaxKey,
 	})
-)
-
-const (
-	// maxBatchSize maximum size of inmemory batch before commit.
-	maxBatchSize = 16 * 1024 * 1024
 )
 
 // UpdateResult if operation succeeded or not, both values mean that operation finished, value just indicates with which result.
@@ -231,136 +224,6 @@ func (p *FSM) openDB(dbdir string) (*pebble.DB, error) {
 	)
 }
 
-// runGC performs an explicit MVCC garbage collection sweep up to the given
-// raft index. It iterates every physical key in the user keyspace and deletes:
-//   - any version with seqno < gcIndex that is shadowed by a newer version
-//     of the same logical user key (i.e. the same key prefix), and
-//   - any tombstone version with seqno < gcIndex that has no newer live
-//     version above gcIndex.
-//
-// Deletions are batched; when the batch reaches maxBatchSize it is committed
-// and a new one is opened. After all obsolete versions are removed, pebble's
-// Compact is called over the full user keyspace so the deleted entries are
-// physically reclaimed from disk.
-func (p *FSM) runGC(db *pebble.DB, gcIndex uint64) error {
-	if gcIndex == 0 {
-		return nil
-	}
-
-	// Scan the entire user keyspace using a snapshot so the view is stable
-	// for the duration of the sweep.
-	snap := db.NewSnapshot()
-	defer snap.Close()
-
-	// The MVCC seqno block property filter lets pebble skip entire SST blocks
-	// whose recorded seqno interval does not intersect [0, gcIndex). Blocks
-	// where every key has seqno >= gcIndex contain nothing the GC can touch and
-	// are skipped without even being opened, dramatically reducing I/O for
-	// databases with mostly-recent data.
-	seqnoFilter := rp.NewMVCCSeqnoFilter(gcIndex)
-	iter, err := snap.NewIter(&pebble.IterOptions{
-		LowerBound:      mustEncodeKey(key.Key{KeyType: key.TypeUser, Key: key.LatestMinKey}),
-		UpperBound:      incrementRightmostByte(append([]byte(nil), maxUserKey...)),
-		PointKeyFilters: []pebble.BlockPropertyFilter{seqnoFilter},
-	})
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-
-	batch := db.NewBatch(pebble.WithInitialSizeBytes(maxBatchSize))
-
-	// lastPrefix holds the user-key prefix (physical key minus the seqno
-	// suffix) of the most recently visited entry. Because pebble iterates in
-	// ascending key order and within the same prefix in descending seqno
-	// order (latest first), the first time we see a prefix is the newest
-	// version — all subsequent visits to the same prefix are older versions
-	// and are therefore shadowed.
-	var lastPrefix []byte
-	var lastPrefixIsTombstone bool
-
-	commitBatch := func() error {
-		if batch.Count() == 0 {
-			return nil
-		}
-		if err := batch.Commit(pebble.NoSync); err != nil {
-			return err
-		}
-		batch = db.NewBatch(pebble.WithInitialSizeBytes(maxBatchSize))
-		return nil
-	}
-
-	for iter.First(); iter.Valid(); iter.Next() {
-		physKey := iter.Key()
-
-		// Decode the logical key to get keyType and seqno.
-		k, err := key.DecodeBytes(physKey)
-		if err != nil {
-			return err
-		}
-		// Only GC user keys; system keys have no MVCC versions.
-		if k.KeyType != key.TypeUser {
-			continue
-		}
-
-		// Prefix = everything except the trailing seqno bytes.
-		prefixLen := len(physKey) - key.V2SeqLen
-		prefix := physKey[:prefixLen]
-
-		sameAsLast := bytes.Equal(lastPrefix, prefix)
-
-		if k.Seqno >= gcIndex {
-			// This version is at or above the safe horizon — always keep it.
-			// Update prefix tracking. lastPrefixIsTombstone is intentionally
-			// not set here — it is only meaningful for the first version below
-			// gcIndex (the else branch below), where it decides whether to keep
-			// or discard a live-but-old value.
-			if !sameAsLast {
-				lastPrefix = append(lastPrefix[:0], prefix...)
-			}
-			continue
-		}
-
-		// Version is below gcIndex.
-		if sameAsLast {
-			// Shadowed by the newer version we already decided to keep (or
-			// already GC'd). Discard regardless.
-			physKeyCopy := make([]byte, len(physKey))
-			copy(physKeyCopy, physKey)
-			if err := batch.Delete(physKeyCopy, nil); err != nil {
-				return err
-			}
-		} else {
-			// First (newest) version of this prefix below gcIndex.
-			lastPrefix = append(lastPrefix[:0], prefix...)
-			lastPrefixIsTombstone = isTombstone(iter.Value())
-
-			if lastPrefixIsTombstone {
-				// Tombstone with no live version above gcIndex — discard.
-				physKeyCopy := make([]byte, len(physKey))
-				copy(physKeyCopy, physKey)
-				if err := batch.Delete(physKeyCopy, nil); err != nil {
-					return err
-				}
-			}
-			// Live value below gcIndex with no newer version — keep it.
-		}
-
-		if uint64(batch.Len()) >= maxBatchSize {
-			if err := commitBatch(); err != nil {
-				return err
-			}
-			time.Sleep(gcThrottleSleep)
-		}
-	}
-
-	if err := commitBatch(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Lookup locally looks up the data.
 func (p *FSM) Lookup(l interface{}) (interface{}, error) {
 	switch req := l.(type) {
@@ -534,57 +397,6 @@ func (p *FSM) notifyRecovered() {
 	gcH, _ := readLocalIndex(p.pebble.Load(), sysGCHorizon)
 	p.gcHorizon.Store(gcH)
 	p.signalGCWorker()
-}
-
-// signalGCWorker sends a non-blocking signal to the GC worker to start a sweep.
-func (p *FSM) signalGCWorker() {
-	select {
-	case p.gcCh <- struct{}{}:
-	default:
-	}
-}
-
-const (
-	gcWorkerPeriod  = 10 * time.Minute
-	gcThrottleSleep = 5 * time.Millisecond // pause between batch commits
-	gcThrottleBatch = 512                  // keys processed per batch before sleeping
-)
-
-// startGCWorker launches the background goroutine that performs throttled
-// MVCC GC sweeps. It is started by Open() and stopped by Close().
-func (p *FSM) startGCWorker() {
-	go func() {
-		defer close(p.gcDone)
-		ticker := time.NewTicker(gcWorkerPeriod)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-p.gcStop:
-				return
-			case <-p.gcCh:
-				p.runGCSweep()
-			case <-ticker.C:
-				p.runGCSweep()
-			}
-		}
-	}()
-}
-
-// runGCSweep runs a single throttled MVCC GC sweep using the current gcHorizon.
-func (p *FSM) runGCSweep() {
-	horizon := p.gcHorizon.Load()
-	if horizon == 0 {
-		return
-	}
-	db := p.pebble.Load()
-	if db == nil {
-		return
-	}
-	if err := p.runGC(db, horizon); err != nil {
-		if !stderrors.Is(err, pebble.ErrClosed) {
-			p.log.Warnf("GC sweep at horizon %d failed: %v", horizon, err)
-		}
-	}
 }
 
 // GetHash gets the DB hash for test comparison.

--- a/storage/table/fsm/fsm_gc.go
+++ b/storage/table/fsm/fsm_gc.go
@@ -1,0 +1,236 @@
+// Copyright JAMF Software, LLC
+
+package fsm
+
+import (
+	"bytes"
+	"encoding/binary"
+	stderrors "errors"
+	"time"
+
+	rp "github.com/armadakv/armada/pebble"
+	"github.com/armadakv/armada/storage/table/key"
+	"github.com/cockroachdb/pebble/v2"
+)
+
+const (
+	// maxBatchSize maximum size of inmemory batch before commit.
+	maxBatchSize    = 16 * 1024 * 1024
+	gcWorkerPeriod  = 10 * time.Minute
+	gcThrottleSleep = 5 * time.Millisecond // pause between batch commits
+	gcThrottleBatch = 512                  // keys processed per batch before sleeping
+)
+
+// gcPrefixUpper returns the exclusive upper bound for all physical keys sharing
+// the same V2 user-key prefix. The V2 prefix ends with a \x00 separator byte;
+// replacing it with \x01 produces a key that sorts strictly after every
+// seqno-suffixed version of that user key and strictly before the first
+// physical key of the next user key. This is safe because user keys cannot
+// contain \x00 bytes (validated at the gRPC layer), so no user key of the form
+// userKey+"\x00"+... can exist to confuse the boundary.
+func gcPrefixUpper(prefix []byte) []byte {
+	upper := make([]byte, len(prefix))
+	copy(upper, prefix)
+	upper[len(upper)-1] = 0x01 // replace \x00 separator with \x01
+	return upper
+}
+
+// incrementStoredSeqno returns a new physical key identical to physKey except
+// that the 8-byte big-endian stored seqno in the tail is incremented by one.
+// Because stored seqno = ^seqno, incrementing it corresponds to decrementing
+// the logical seqno by one — the resulting key is the physical key that would
+// immediately follow physKey within the same prefix group.
+func incrementStoredSeqno(physKey []byte) []byte {
+	out := make([]byte, len(physKey))
+	copy(out, physKey)
+	seqStart := len(out) - key.V2SeqLen
+	stored := binary.BigEndian.Uint64(out[seqStart:])
+	binary.BigEndian.PutUint64(out[seqStart:], stored+1)
+	return out
+}
+
+// runGC performs an explicit MVCC garbage collection sweep up to the given
+// raft index. It iterates every physical key in the user keyspace and issues
+// DeleteRange tombstones to remove:
+//   - all versions with seqno < gcIndex that are shadowed by a newer version
+//     of the same logical user key (same key prefix), and
+//   - tombstone versions with seqno < gcIndex that have no live version above
+//     gcIndex (the key was deleted before the GC horizon).
+//
+// For each user-key prefix the sweep encounters the first old version (seqno <
+// gcIndex), determines the range start, and issues a single DeleteRange from
+// that start up to gcPrefixUpper(prefix).  It then calls iter.SeekGE to jump
+// directly to the next prefix, skipping all remaining old versions without
+// visiting them individually.  This reduces both iterator steps and batch
+// entries from O(old-versions) to O(distinct-user-keys).
+//
+// Three cases per prefix:
+//  1. A live version at seqno >= gcIndex exists (hasLiveAbove): delete the
+//     first old version and everything older → DeleteRange(firstOld, upper).
+//  2. No version >= gcIndex and the newest old version is a tombstone: the key
+//     was deleted before the horizon; delete tombstone and everything older →
+//     DeleteRange(firstOld, upper).
+//  3. No version >= gcIndex and the newest old version is a live value: this is
+//     the current live version of the key — keep it; delete any older versions
+//     → DeleteRange(firstOld+1, upper).  A no-op when there are no older ones.
+//
+// Deletions are batched; when the batch reaches maxBatchSize it is committed
+// and a new one is opened. After all obsolete versions are removed, pebble's
+// Compact is called over the full user keyspace so the deleted entries are
+// physically reclaimed from disk.
+func (p *FSM) runGC(db *pebble.DB, gcIndex uint64) error {
+	if gcIndex == 0 {
+		return nil
+	}
+
+	// Scan the entire user keyspace using a snapshot so the view is stable
+	// for the duration of the sweep.
+	snap := db.NewSnapshot()
+	defer snap.Close()
+
+	// The MVCC seqno block property filter lets pebble skip entire SST blocks
+	// whose recorded seqno interval does not intersect [0, gcIndex). Blocks
+	// where every key has seqno >= gcIndex contain nothing the GC can touch and
+	// are skipped without even being opened, dramatically reducing I/O for
+	// databases with mostly-recent data.
+	seqnoFilter := rp.NewMVCCSeqnoFilter(gcIndex)
+	iter, err := snap.NewIter(&pebble.IterOptions{
+		LowerBound:      mustEncodeKey(key.Key{KeyType: key.TypeUser, Key: key.LatestMinKey}),
+		UpperBound:      incrementRightmostByte(append([]byte(nil), maxUserKey...)),
+		PointKeyFilters: []pebble.BlockPropertyFilter{seqnoFilter},
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	batch := db.NewBatch(pebble.WithInitialSizeBytes(maxBatchSize))
+
+	var (
+		lastPrefix   []byte
+		hasLiveAbove bool
+	)
+
+	commitBatch := func() error {
+		if batch.Count() == 0 {
+			return nil
+		}
+		if err := batch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		batch = db.NewBatch(pebble.WithInitialSizeBytes(maxBatchSize))
+		return nil
+	}
+
+	// Use a manual advance loop so we can call iter.SeekGE to jump past all
+	// old versions of a prefix in a single step instead of visiting each one.
+	for valid := iter.First(); valid; {
+		physKey := iter.Key()
+
+		// Decode the logical key to get keyType and seqno.
+		k, err := key.DecodeBytes(physKey)
+		if err != nil {
+			return err
+		}
+		// Only GC user keys; system keys have no MVCC versions.
+		if k.KeyType != key.TypeUser {
+			valid = iter.Next()
+			continue
+		}
+
+		// Prefix = everything except the trailing seqno bytes.
+		prefixLen := len(physKey) - key.V2SeqLen
+		prefix := physKey[:prefixLen]
+
+		if !bytes.Equal(lastPrefix, prefix) {
+			lastPrefix = append(lastPrefix[:0], prefix...)
+			hasLiveAbove = false
+		}
+
+		if k.Seqno >= gcIndex {
+			// This version is at or above the safe horizon — always keep it.
+			hasLiveAbove = true
+			valid = iter.Next()
+			continue
+		}
+
+		// First old version of this prefix (SeekGE below will skip any
+		// further old versions so this branch executes at most once per prefix).
+		prefixUpper := gcPrefixUpper(prefix)
+
+		var rangeLo []byte
+		if hasLiveAbove || isTombstone(iter.Value()) {
+			// Cases 1 & 2: delete the first old key and everything older.
+			rangeLo = make([]byte, len(physKey))
+			copy(rangeLo, physKey)
+		} else {
+			// Case 3: keep the current (live) version; delete any older ones.
+			rangeLo = incrementStoredSeqno(physKey)
+		}
+
+		if err := batch.DeleteRange(rangeLo, prefixUpper, nil); err != nil {
+			return err
+		}
+
+		if uint64(batch.Len()) >= maxBatchSize {
+			if err := commitBatch(); err != nil {
+				return err
+			}
+			time.Sleep(gcThrottleSleep)
+		}
+
+		// Jump directly to the next prefix, skipping all remaining old versions.
+		valid = iter.SeekGE(prefixUpper)
+	}
+
+	if err := commitBatch(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// signalGCWorker sends a non-blocking signal to the GC worker to start a sweep.
+func (p *FSM) signalGCWorker() {
+	select {
+	case p.gcCh <- struct{}{}:
+	default:
+	}
+}
+
+// startGCWorker launches the background goroutine that performs throttled
+// MVCC GC sweeps. It is started by Open() and stopped by Close().
+func (p *FSM) startGCWorker() {
+	go func() {
+		defer close(p.gcDone)
+		ticker := time.NewTicker(gcWorkerPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-p.gcStop:
+				return
+			case <-p.gcCh:
+				p.runGCSweep()
+			case <-ticker.C:
+				p.runGCSweep()
+			}
+		}
+	}()
+}
+
+// runGCSweep runs a single throttled MVCC GC sweep using the current gcHorizon.
+func (p *FSM) runGCSweep() {
+	horizon := p.gcHorizon.Load()
+	if horizon == 0 {
+		return
+	}
+	db := p.pebble.Load()
+	if db == nil {
+		return
+	}
+	if err := p.runGC(db, horizon); err != nil {
+		if !stderrors.Is(err, pebble.ErrClosed) {
+			p.log.Warnf("GC sweep at horizon %d failed: %v", horizon, err)
+		}
+	}
+}

--- a/storage/table/fsm/fsm_gc_test.go
+++ b/storage/table/fsm/fsm_gc_test.go
@@ -1,0 +1,503 @@
+// Copyright JAMF Software, LLC
+
+package fsm
+
+import (
+	"math"
+	"testing"
+
+	"github.com/armadakv/armada/armadapb"
+	sm "github.com/armadakv/armada/raft/statemachine"
+	"github.com/armadakv/armada/storage/table/key"
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// physicalVersionCount returns the number of raw Pebble entries that exist for
+// the given user key across all MVCC versions (including tombstones, including
+// versions that are logically invisible due to shadowing).
+func physicalVersionCount(db *pebble.DB, userKey []byte) int {
+	// Build the prefix: [4B header][TypeUser][userKey][0x00 sep]
+	ref := mustEncodeKey(key.Key{KeyType: key.TypeUser, Key: userKey})
+	prefixLen := len(ref) - key.V2SeqLen
+	prefix := ref[:prefixLen]
+
+	// Lower bound: prefix + 8 zero bytes → stored seqno = 0 → seqno = MaxUint64
+	// (sorts FIRST within the prefix group, i.e. newest version).
+	lo := make([]byte, len(prefix)+key.V2SeqLen)
+	copy(lo, prefix)
+
+	// Upper bound: replace trailing 0x00 separator with 0x01.
+	hi := gcPrefixUpper(prefix)
+
+	snap := db.NewSnapshot()
+	defer snap.Close()
+
+	iter, err := snap.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
+	if err != nil {
+		panic(err)
+	}
+	defer iter.Close()
+
+	n := 0
+	for valid := iter.First(); valid; valid = iter.Next() {
+		n++
+	}
+	return n
+}
+
+// lookupVisible returns the current visible value for userKey, or nil if the
+// key is absent (including when it has been tombstoned).
+func lookupVisible(t *testing.T, p *FSM, userKey []byte) []byte {
+	t.Helper()
+	res, err := p.Lookup(&armadapb.RequestOp_Range{Key: userKey})
+	require.NoError(t, err)
+	resp := res.(*armadapb.ResponseOp_Range)
+	if len(resp.Kvs) == 0 {
+		return nil
+	}
+	return resp.Kvs[0].Value
+}
+
+// putEntry builds an sm.Entry that writes key→value at the given raft index
+// (which becomes the MVCC seqno when no LeaderIndex is set).
+func putEntry(idx uint64, userKey, value []byte) sm.Entry {
+	return sm.Entry{
+		Index: idx,
+		Cmd: mustMarshallProto(&armadapb.Command{
+			Type: armadapb.Command_PUT,
+			Kv:   &armadapb.KeyValue{Key: userKey, Value: value},
+		}),
+	}
+}
+
+// deleteEntry builds an sm.Entry that writes a tombstone for key at the given
+// raft index.
+func deleteEntry(idx uint64, userKey []byte) sm.Entry {
+	return sm.Entry{
+		Index: idx,
+		Cmd: mustMarshallProto(&armadapb.Command{
+			Type: armadapb.Command_DELETE,
+			Kv:   &armadapb.KeyValue{Key: userKey},
+		}),
+	}
+}
+
+// applyEntries drives entries through the FSM and panics on error.
+func applyEntries(p *FSM, entries ...sm.Entry) {
+	if _, err := p.Update(entries); err != nil {
+		panic(err)
+	}
+}
+
+func TestRunGC_ZeroIndex(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p, putEntry(1, []byte("k"), []byte("v")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 0))
+	// gcIndex 0 is a no-op; key must still be visible.
+	require.Equal(t, []byte("v"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+func TestRunGC_EmptyDatabase(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 100))
+}
+
+// Case 3: single live version below gcIndex, no version above.
+// The key must be kept (it is the current version of the key).
+func TestRunGC_SingleLiveVersionBelowHorizon_Kept(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p, putEntry(3, []byte("k"), []byte("v3")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	require.Equal(t, []byte("v3"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Case 2: single tombstone version below gcIndex, no version above.
+// The tombstone must be deleted (the key was deleted before the GC horizon).
+func TestRunGC_SingleTombstoneBelowHorizon_Deleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		deleteEntry(3, []byte("k")),
+	)
+	require.Equal(t, 2, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	require.Nil(t, lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 0, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Case 3 with older versions: multiple live versions all below gcIndex.
+// Newest must be kept; all older versions must be removed.
+func TestRunGC_MultipleLiveVersionsBelowHorizon_KeepNewestDeleteRest(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(2, []byte("k"), []byte("v2")),
+		putEntry(4, []byte("k"), []byte("v4")),
+	)
+	require.Equal(t, 3, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	require.Equal(t, []byte("v4"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Tombstone is newest below gcIndex and there are older live versions below it.
+// All versions (tombstone + older) must be removed since the key was deleted.
+func TestRunGC_TombstoneNewest_OlderVersionsBelowHorizon_AllDeleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(2, []byte("k"), []byte("v2")),
+		deleteEntry(4, []byte("k")),
+	)
+	require.Equal(t, 3, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	require.Nil(t, lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 0, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Case 1: live version at seqno >= gcIndex plus old versions below.
+// Old versions must be deleted; live version must be kept.
+func TestRunGC_LiveVersionAboveHorizon_OldVersionsDeleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(3, []byte("k"), []byte("v3")),
+		putEntry(7, []byte("k"), []byte("v7")),
+	)
+	require.Equal(t, 3, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 5))
+
+	require.Equal(t, []byte("v7"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Multiple live versions above gcIndex plus several old versions below.
+// All old versions must be removed; all versions at/above horizon kept.
+func TestRunGC_MultipleLiveVersionsAboveHorizon_OldVersionsDeleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(2, []byte("k"), []byte("v2")),
+		putEntry(3, []byte("k"), []byte("v3")),
+		putEntry(7, []byte("k"), []byte("v7")),
+		putEntry(9, []byte("k"), []byte("v9")),
+	)
+	require.Equal(t, 5, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 5))
+
+	require.Equal(t, []byte("v9"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 2, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Case 1 with tombstone: live version above gcIndex, tombstone below gcIndex.
+// Tombstone must be deleted; live version kept.
+func TestRunGC_TombstoneBelowHorizon_LiveVersionAbove_TombstoneDeleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		deleteEntry(3, []byte("k")),
+		putEntry(7, []byte("k"), []byte("v7")),
+	)
+	require.Equal(t, 3, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 5))
+
+	require.Equal(t, []byte("v7"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// All versions are at or above gcIndex → nothing should be removed.
+func TestRunGC_AllVersionsAboveHorizon_NothingDeleted(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(5, []byte("k"), []byte("v5")),
+		putEntry(7, []byte("k"), []byte("v7")),
+	)
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 5))
+
+	require.Equal(t, []byte("v7"), lookupVisible(t, p, []byte("k")))
+	require.Equal(t, 2, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// gcIndex exactly at a version boundary: seqno == gcIndex must be kept.
+func TestRunGC_ExactBoundary_SeqnoAtGCIndex_Kept(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(5, []byte("k"), []byte("v5")), // seqno == gcIndex
+	)
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 5))
+
+	require.Equal(t, []byte("v5"), lookupVisible(t, p, []byte("k")))
+	// seqno=5 >= gcIndex=5 (kept), seqno=1 < gcIndex=5 (deleted)
+	require.Equal(t, 1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+}
+
+// Multiple keys — each processed independently and correctly.
+func TestRunGC_MultipleKeys_IndependentProcessing(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	const gcIdx = uint64(5)
+
+	// key "a": live above horizon + old below → old deleted
+	applyEntries(p,
+		putEntry(1, []byte("a"), []byte("a1")),
+		putEntry(7, []byte("a"), []byte("a7")),
+	)
+	// key "b": tombstone only below horizon → deleted
+	applyEntries(p,
+		putEntry(2, []byte("b"), []byte("b2")),
+		deleteEntry(3, []byte("b")),
+	)
+	// key "c": single live below horizon → kept
+	applyEntries(p,
+		putEntry(4, []byte("c"), []byte("c4")),
+	)
+	// key "d": multiple versions above horizon → all kept
+	applyEntries(p,
+		putEntry(6, []byte("d"), []byte("d6")),
+		putEntry(8, []byte("d"), []byte("d8")),
+	)
+
+	require.NoError(t, p.runGC(p.pebble.Load(), gcIdx))
+
+	db := p.pebble.Load()
+
+	require.Equal(t, []byte("a7"), lookupVisible(t, p, []byte("a")))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("a")))
+
+	require.Nil(t, lookupVisible(t, p, []byte("b")))
+	require.Equal(t, 0, physicalVersionCount(db, []byte("b")))
+
+	require.Equal(t, []byte("c4"), lookupVisible(t, p, []byte("c")))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("c")))
+
+	require.Equal(t, []byte("d8"), lookupVisible(t, p, []byte("d")))
+	require.Equal(t, 2, physicalVersionCount(db, []byte("d")))
+}
+
+// Prefix-boundary safety: "foo" and "foobar" are distinct user keys.
+// GC on "foo" must not affect "foobar" versions.
+func TestRunGC_PrefixBoundarySafety(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		// "foo": 3 versions, all below gcIndex → keep only newest
+		putEntry(1, []byte("foo"), []byte("foo1")),
+		putEntry(2, []byte("foo"), []byte("foo2")),
+		putEntry(3, []byte("foo"), []byte("foo3")),
+		// "foobar": 2 versions, all below gcIndex → keep only newest
+		putEntry(1, []byte("foobar"), []byte("foobar1")),
+		putEntry(4, []byte("foobar"), []byte("foobar4")),
+	)
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	db := p.pebble.Load()
+	require.Equal(t, []byte("foo3"), lookupVisible(t, p, []byte("foo")))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("foo")))
+
+	require.Equal(t, []byte("foobar4"), lookupVisible(t, p, []byte("foobar")))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("foobar")))
+}
+
+// Keys containing 0x01 bytes must not be confused with the gcPrefixUpper boundary.
+func TestRunGC_KeyContainingOxO1Bytes(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	key1 := []byte("foo")
+	key2 := []byte{'f', 'o', 'o', 0x01, 'b', 'a', 'r'} // "foo\x01bar"
+
+	applyEntries(p,
+		putEntry(1, key1, []byte("foo-v1")),
+		putEntry(3, key1, []byte("foo-v3")),
+		putEntry(2, key2, []byte("foobar01-v2")),
+		putEntry(4, key2, []byte("foobar01-v4")),
+	)
+
+	require.NoError(t, p.runGC(p.pebble.Load(), 10))
+
+	db := p.pebble.Load()
+	require.Equal(t, []byte("foo-v3"), lookupVisible(t, p, key1))
+	require.Equal(t, 1, physicalVersionCount(db, key1))
+
+	require.Equal(t, []byte("foobar01-v4"), lookupVisible(t, p, key2))
+	require.Equal(t, 1, physicalVersionCount(db, key2))
+}
+
+// Large number of versions ensures the SeekGE-based loop is exercised under
+// realistic conditions and produces a correct result.
+func TestRunGC_ManyVersions(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	const (
+		totalVersions = 100
+		gcIdx         = uint64(80)
+	)
+
+	entries := make([]sm.Entry, totalVersions)
+	for i := range entries {
+		entries[i] = putEntry(uint64(i+1), []byte("k"), []byte{byte(i + 1)})
+	}
+	applyEntries(p, entries...)
+	require.Equal(t, totalVersions, physicalVersionCount(p.pebble.Load(), []byte("k")))
+
+	require.NoError(t, p.runGC(p.pebble.Load(), gcIdx))
+
+	// seqno 80..100 survive (>= gcIdx), seqno 1..79 are deleted.
+	// (seqno 80 is the first kept: 80 >= gcIdx=80)
+	require.Equal(t, totalVersions-int(gcIdx)+1, physicalVersionCount(p.pebble.Load(), []byte("k")))
+	require.Equal(t, []byte{byte(totalVersions)}, lookupVisible(t, p, []byte("k")))
+}
+
+// Idempotency: running GC twice with the same horizon must not change results.
+func TestRunGC_Idempotent(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(3, []byte("k"), []byte("v3")),
+		putEntry(7, []byte("k"), []byte("v7")),
+	)
+
+	db := p.pebble.Load()
+	require.NoError(t, p.runGC(db, 5))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("k")))
+
+	require.NoError(t, p.runGC(db, 5))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("k")))
+	require.Equal(t, []byte("v7"), lookupVisible(t, p, []byte("k")))
+}
+
+// Increasing horizon: subsequent GC sweeps with higher gcIndex correctly
+// clean up versions that were previously kept.
+func TestRunGC_IncreasingHorizon(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	applyEntries(p,
+		putEntry(1, []byte("k"), []byte("v1")),
+		putEntry(3, []byte("k"), []byte("v3")),
+		putEntry(7, []byte("k"), []byte("v7")),
+		putEntry(9, []byte("k"), []byte("v9")),
+	)
+
+	db := p.pebble.Load()
+
+	// First sweep: gcIndex=5 → seqno 1,3 deleted; seqno 7,9 kept.
+	require.NoError(t, p.runGC(db, 5))
+	require.Equal(t, 2, physicalVersionCount(db, []byte("k")))
+	require.Equal(t, []byte("v9"), lookupVisible(t, p, []byte("k")))
+
+	// Second sweep: gcIndex=8 → seqno 7 now below horizon; only seqno 9 survives.
+	require.NoError(t, p.runGC(db, 8))
+	require.Equal(t, 1, physicalVersionCount(db, []byte("k")))
+	require.Equal(t, []byte("v9"), lookupVisible(t, p, []byte("k")))
+}
+
+// Ensure the helper gcPrefixUpper correctly replaces the trailing separator.
+func TestGCPrefixUpper(t *testing.T) {
+	r := require.New(t)
+	ref := mustEncodeKey(key.Key{KeyType: key.TypeUser, Key: []byte("foo")})
+	prefixLen := len(ref) - key.V2SeqLen
+	prefix := ref[:prefixLen]
+
+	upper := gcPrefixUpper(prefix)
+	r.Len(upper, prefixLen)
+	r.Equal(byte(0x01), upper[len(upper)-1])
+
+	// upper must sort strictly after any key that starts with prefix+0x00.
+	// (i.e. all physical versions of "foo")
+	r.Less(string(ref), string(upper)) // ref has 0xFF...FF seqno, upper has 0x01 after prefix
+}
+
+// Ensure incrementStoredSeqno produces a key that sorts immediately after
+// the input within the same prefix.
+func TestIncrementStoredSeqno(t *testing.T) {
+	r := require.New(t)
+
+	// Encode key "k" at seqno=42.
+	ref := mustEncodeKey(key.Key{KeyType: key.TypeUser, Key: []byte("k"), Seqno: 42})
+	next := incrementStoredSeqno(ref)
+
+	// next must be strictly greater than ref and still share the same prefix.
+	r.Greater(string(next), string(ref))
+
+	prefixLen := len(ref) - key.V2SeqLen
+	r.Equal(ref[:prefixLen], next[:prefixLen])
+
+	// The stored seqno in next must equal stored(42)+1.
+	// stored(42) = ^42; next stored = ^42 + 1.
+	storedRef := uint64(0)
+	for i := prefixLen; i < len(ref); i++ {
+		storedRef = storedRef<<8 | uint64(ref[i])
+	}
+	storedNext := uint64(0)
+	for i := prefixLen; i < len(next); i++ {
+		storedNext = storedNext<<8 | uint64(next[i])
+	}
+	r.Equal(storedRef+1, storedNext)
+}
+
+// Sanity-check that physicalVersionCount correctly counts entries including
+// those with seqno = math.MaxUint64 (which maps to stored seqno = 0).
+func TestPhysicalVersionCount_IncludesMaxSeqno(t *testing.T) {
+	p := emptySM()
+	defer func() { require.NoError(t, p.Close()) }()
+
+	// Seqno math.MaxUint64 is the largest possible; stored = 0 (sorts first).
+	// We use a raw Pebble write to inject this extreme case.
+	db := p.pebble.Load()
+
+	b := db.NewBatch()
+	buf := bufferPool.Get()
+	require.NoError(t, encodeUserKey(buf, []byte("extreme"), math.MaxUint64))
+	require.NoError(t, b.Set(buf.Bytes(), []byte("vmax"), nil))
+	bufferPool.Put(buf)
+	require.NoError(t, b.Commit(pebble.NoSync))
+
+	require.Equal(t, 1, physicalVersionCount(db, []byte("extreme")))
+}


### PR DESCRIPTION
This pull request introduces two major improvements to the codebase: (1) strict validation to prevent null bytes in user keys for all KV operations, and (2) new Prometheus metrics to report disk usage for storage directories. It also includes comprehensive unit tests for both features and integrates the new disk metrics into the storage engine.

**Key-Value API Improvements:**

* Added validation logic to reject user keys and range endpoints containing null bytes in all KV operations, to prevent ambiguity in physical key encoding and ensure correct MVCC behavior. Special handling allows the single-byte `\x00` sentinel where appropriate (e.g., as a wildcard for range scans). [[1]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428R19-R95) [[2]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428L46-R135) [[3]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428R173-R180) [[4]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428R220-R223) [[5]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428R247-R254) [[6]](diffhunk://#diff-0159b3536aabed2a71337702749c6cfe1d69017d4fd0452c1536ecb96885e428R277-R280)
* Added extensive unit tests to verify correct enforcement of null byte restrictions and proper handling of sentinel values in all relevant request types.

**Observability and Metrics:**

* Implemented a new Prometheus `Collector` (`diskMetrics`) that reports the on-disk size (in bytes) of the Raft log, WAL directory, and table state-machine data by recursively walking their directories.
* Integrated the disk metrics collector into the `Engine` type, exposing `Describe` and `Collect` methods, and registered the engine as a collector in the server startup. [[1]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R21) [[2]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R69-R82) [[3]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R93) [[4]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R18) [[5]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R117)
* Added unit tests for directory size calculation and metric collection, including edge cases such as non-existent and colocated WAL directories.