### PR TITLE
feat: QUIC buffer cap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/armadaserver/armadaserver_test.go
+++ b/armadaserver/armadaserver_test.go
@@ -57,13 +57,14 @@ func newInMemTestEngine(t *testing.T, tables ...string) *storage.Engine {
 	gossipAddr := testAddr()
 
 	e, err := storage.New(storage.Config{
-		ClientAddress:  raftAddr,
-		NodeID:         1,
-		InitialMembers: map[uint64]string{1: raftAddr},
-		NodeHostDir:    "/nh",
-		RTTMillisecond: 10,
-		RaftAddress:    raftAddr,
-		EnableMetrics:  false,
+		ClientAddress:     raftAddr,
+		NodeID:            1,
+		InitialMembers:    map[uint64]string{1: raftAddr},
+		NodeHostDir:       "/nh",
+		RTTMillisecond:    10,
+		RaftAddress:       raftAddr,
+		EnableMetrics:     false,
+		QUICUDPBufferSize: 4 * 1024 * 1024, // 4 MiB — fits within most CI kernel limits
 		Gossip: storage.GossipConfig{
 			ClusterName:    uuid.New().String(),
 			BindAddress:    gossipAddr,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -94,6 +94,10 @@ dropped to restrict memory usage. When set to 0, it means the queue size is unli
 	raftFlagSet.Uint64("raft.max-send-queue-size", 0,
 		`MaxSendQueueSize is the maximum size in bytes of each send queue. Once the maximum size is reached, further replication messages will be
 dropped to restrict memory usage. When set to 0, it means the send queue size is unlimited.`)
+	raftFlagSet.Int("raft.quic-udp-buffer-size", 0,
+		`QUICUDPBufferSize is the UDP socket receive/send buffer size in bytes requested for the QUIC transport.
+When set to a positive value the QUIC library's buffer requests are capped at this value, preventing log warnings on systems
+where the kernel UDP buffer limit is lower than the library default (7 MiB). A value of 0 uses the library default.`)
 	memberlistFlagSet.String("memberlist.address", "0.0.0.0:7432", `Address is the address for the gossip service to bind to and listen on. Both UDP and TCP ports are used by the gossip service.
 The local gossip service should be able to receive gossip service related messages by binding to and listening on this address. BindAddress is usually in the format of IP:Port, Hostname:Port or DNS Name:Port.`)
 	memberlistFlagSet.String("memberlist.advertise-address", "", `AdvertiseAddress is the address to advertise to other Armada instances used for NAT traversal.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -60,6 +60,7 @@ func createEngineConfig(engineLog *zap.Logger, appliedIndexListener func(table s
 		EnableMetrics:       true,
 		MaxReceiveQueueSize: viper.GetUint64("raft.max-recv-queue-size"),
 		MaxSendQueueSize:    viper.GetUint64("raft.max-send-queue-size"),
+		QUICUDPBufferSize:   viper.GetInt("raft.quic-udp-buffer-size"),
 		Gossip: storage.GossipConfig{
 			BindAddress:      viper.GetString("memberlist.address"),
 			AdvertiseAddress: viper.GetString("memberlist.advertise-address"),

--- a/raft/config/config.go
+++ b/raft/config/config.go
@@ -329,14 +329,14 @@ type NodeHostConfig struct {
 	// commits are not notified, clients are only notified when their proposals
 	// are both committed and applied.
 	NotifyCommit bool
-	// QUICUDPBufferSize is the desired UDP socket receive and send buffer size
-	// in bytes for the QUIC transport. When set to a positive value, the QUIC
-	// transport will request this buffer size from the OS kernel and will also
-	// cap any subsequent attempts by the QUIC library to increase the buffer
-	// beyond this value. This is useful on systems where the kernel enforces a
-	// low maximum UDP buffer size (e.g. some CI environments where
-	// net.core.rmem_max is only 4096 bytes). When set to 0 (the default), the
-	// QUIC library chooses its own default (currently 7 MiB) and the kernel
+	// QUICUDPBufferSize is the maximum UDP socket receive and send buffer size
+	// in bytes that the QUIC transport will request from the OS kernel. When
+	// set to a positive value, the QUIC transport caps buffer size requests made
+	// by the QUIC library at this value, but it does not increase smaller
+	// library requests up to this size. This is useful on systems where the
+	// kernel enforces a low maximum UDP buffer size (e.g. some CI environments
+	// where net.core.rmem_max is only 4096 bytes). When set to 0 (the default),
+	// the QUIC library chooses its own default (currently 7 MiB) and the kernel
 	// maximum determines whether that request succeeds.
 	QUICUDPBufferSize int
 	// Expert contains options for expert users who are familiar with the internals

--- a/raft/config/config.go
+++ b/raft/config/config.go
@@ -329,6 +329,16 @@ type NodeHostConfig struct {
 	// commits are not notified, clients are only notified when their proposals
 	// are both committed and applied.
 	NotifyCommit bool
+	// QUICUDPBufferSize is the desired UDP socket receive and send buffer size
+	// in bytes for the QUIC transport. When set to a positive value, the QUIC
+	// transport will request this buffer size from the OS kernel and will also
+	// cap any subsequent attempts by the QUIC library to increase the buffer
+	// beyond this value. This is useful on systems where the kernel enforces a
+	// low maximum UDP buffer size (e.g. some CI environments where
+	// net.core.rmem_max is only 4096 bytes). When set to 0 (the default), the
+	// QUIC library chooses its own default (currently 7 MiB) and the kernel
+	// maximum determines whether that request succeeds.
+	QUICUDPBufferSize int
 	// Expert contains options for expert users who are familiar with the internals
 	// of Dragonboat. Users are recommended not to use this field unless
 	// absolutely necessary. It is important to note that any change to this field

--- a/raft/internal/transport/quic.go
+++ b/raft/internal/transport/quic.go
@@ -253,11 +253,22 @@ func (t *QUIC) Start() error {
 	// Create the UDP socket ourselves so we can close it explicitly in Close(),
 	// guaranteeing that the port is released.  quic.ListenAddr hides the
 	// Transport internally and listener.Close() does not close the UDP socket.
-	udpConn, err := net.ListenPacket("udp", t.nhConfig.GetListenAddress())
+	pc, err := net.ListenPacket("udp", t.nhConfig.GetListenAddress())
 	if err != nil {
 		return err
 	}
-	qt := &quic.Transport{Conn: udpConn}
+	udpConn := pc.(*net.UDPConn)
+	// Wrap the connection to control the UDP receive/send buffer size.
+	// When QUICUDPBufferSize is set, we cap any buffer-size request (including
+	// those issued internally by quic-go) to that value. This prevents noisy
+	// warnings on systems where the kernel enforces a low SO_RCVBUF maximum
+	// (e.g. constrained CI environments). When the field is 0, the raw
+	// connection is used and quic-go applies its own default (7 MiB).
+	var packetConn net.PacketConn = udpConn
+	if sz := t.nhConfig.QUICUDPBufferSize; sz > 0 {
+		packetConn = newCappedUDPConn(udpConn, sz)
+	}
+	qt := &quic.Transport{Conn: packetConn}
 	listener, err := qt.Listen(tlsConfig, &quic.Config{
 		MaxIdleTimeout:  quicMaxIdleTimeout,
 		KeepAlivePeriod: quicKeepAlivePeriod,
@@ -581,4 +592,35 @@ func selfSignedTLSConfig() (*tls.Config, error) {
 		}},
 		NextProtos: []string{quicALPN},
 	}, nil
+}
+
+// cappedUDPConn wraps a *net.UDPConn and caps SetReadBuffer / SetWriteBuffer
+// calls to a configured maximum. This prevents the QUIC library from
+// requesting a buffer size larger than the OS kernel permits, which would
+// otherwise produce a noisy log warning on systems with a low SO_RCVBUF limit.
+type cappedUDPConn struct {
+	*net.UDPConn
+	maxSize int
+}
+
+// newCappedUDPConn returns a cappedUDPConn that enforces maxSize on every
+// SetReadBuffer / SetWriteBuffer call.
+func newCappedUDPConn(c *net.UDPConn, maxSize int) *cappedUDPConn {
+	return &cappedUDPConn{UDPConn: c, maxSize: maxSize}
+}
+
+// SetReadBuffer caps the requested size and delegates to the underlying conn.
+func (c *cappedUDPConn) SetReadBuffer(n int) error {
+	if n > c.maxSize {
+		n = c.maxSize
+	}
+	return c.UDPConn.SetReadBuffer(n)
+}
+
+// SetWriteBuffer caps the requested size and delegates to the underlying conn.
+func (c *cappedUDPConn) SetWriteBuffer(n int) error {
+	if n > c.maxSize {
+		n = c.maxSize
+	}
+	return c.UDPConn.SetWriteBuffer(n)
 }

--- a/replication/backup/backup_test.go
+++ b/replication/backup/backup_test.go
@@ -314,17 +314,18 @@ func newTestConfig(t *testing.T) storage.Config {
 	raftPort := getTestPort()
 	gossipPort := getTestPort()
 	return storage.Config{
-		Log:            zaptest.NewLogger(t).Sugar(),
-		NodeID:         1,
-		InitialMembers: map[uint64]string{1: fmt.Sprintf("127.0.0.1:%d", raftPort)},
-		WALDir:         "/wal",
-		NodeHostDir:    "/nh",
-		RTTMillisecond: 5,
-		RaftAddress:    fmt.Sprintf("127.0.0.1:%d", raftPort),
-		Gossip:         storage.GossipConfig{BindAddress: fmt.Sprintf("127.0.0.1:%d", gossipPort), InitialMembers: []string{fmt.Sprintf("127.0.0.1:%d", gossipPort)}},
-		Table:          storage.TableConfig{FS: wrapFS(fs), TableCacheSize: 1024, ElectionRTT: 10, HeartbeatRTT: 1},
-		Meta:           storage.MetaConfig{ElectionRTT: 10, HeartbeatRTT: 1},
-		FS:             fs,
+		Log:               zaptest.NewLogger(t).Sugar(),
+		NodeID:            1,
+		InitialMembers:    map[uint64]string{1: fmt.Sprintf("127.0.0.1:%d", raftPort)},
+		WALDir:            "/wal",
+		NodeHostDir:       "/nh",
+		RTTMillisecond:    5,
+		RaftAddress:       fmt.Sprintf("127.0.0.1:%d", raftPort),
+		QUICUDPBufferSize: 4 * 1024 * 1024, // 4 MiB — fits within most CI kernel limits
+		Gossip:            storage.GossipConfig{BindAddress: fmt.Sprintf("127.0.0.1:%d", gossipPort), InitialMembers: []string{fmt.Sprintf("127.0.0.1:%d", gossipPort)}},
+		Table:             storage.TableConfig{FS: wrapFS(fs), TableCacheSize: 1024, ElectionRTT: 10, HeartbeatRTT: 1},
+		Meta:              storage.MetaConfig{ElectionRTT: 10, HeartbeatRTT: 1},
+		FS:                fs,
 	}
 }
 

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -212,9 +212,10 @@ func prepareLeaderAndFollowerEngine(t *testing.T) (leaderTM *storage.Engine, fol
 	t.Log("start leader Raft")
 	leaderAddress := fmt.Sprintf("127.0.0.1:%d", getTestPort())
 	leaderTM, err := storage.New(storage.Config{
-		FS:             vfs.NewMem(),
-		Log:            zaptest.NewLogger(t).Sugar(),
-		InitialMembers: map[uint64]string{1: leaderAddress},
+		FS:                vfs.NewMem(),
+		Log:               zaptest.NewLogger(t).Sugar(),
+		InitialMembers:    map[uint64]string{1: leaderAddress},
+		QUICUDPBufferSize: 4 * 1024 * 1024, // 4 MiB — fits within most CI kernel limits
 		Gossip: storage.GossipConfig{
 			BindAddress: fmt.Sprintf("127.0.0.1:%d", getTestPort()),
 			ClusterName: "leader",
@@ -231,9 +232,10 @@ func prepareLeaderAndFollowerEngine(t *testing.T) (leaderTM *storage.Engine, fol
 	t.Log("start follower Raft")
 	followerAddress := fmt.Sprintf("127.0.0.1:%d", getTestPort())
 	followerTM, err = storage.New(storage.Config{
-		FS:             vfs.NewMem(),
-		Log:            zaptest.NewLogger(t).Sugar(),
-		InitialMembers: map[uint64]string{1: followerAddress},
+		FS:                vfs.NewMem(),
+		Log:               zaptest.NewLogger(t).Sugar(),
+		InitialMembers:    map[uint64]string{1: followerAddress},
+		QUICUDPBufferSize: 4 * 1024 * 1024, // 4 MiB — fits within most CI kernel limits
 		Gossip: storage.GossipConfig{
 			BindAddress: fmt.Sprintf("127.0.0.1:%d", getTestPort()),
 			ClusterName: "follower",

--- a/storage/config.go
+++ b/storage/config.go
@@ -81,6 +81,12 @@ type Config struct {
 	// dropped to restrict memory usage. When set to 0, it means the queue size
 	// is unlimited.
 	MaxReceiveQueueSize uint64
+	// QUICUDPBufferSize is the desired UDP socket receive/send buffer size in
+	// bytes for the QUIC transport. When > 0, the QUIC library's buffer requests
+	// are capped at this value, preventing warnings on systems with a low kernel
+	// maximum (e.g. constrained CI environments). When 0, the QUIC library's
+	// default (currently 7 MiB) is used.
+	QUICUDPBufferSize int
 	// NotifyCommit specifies whether clients should be notified when their
 	// regular proposals and config change requests are committed. By default,
 	// commits are not notified, clients are only notified when their proposals

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -299,6 +299,7 @@ func createNodeHost(e *Engine) (*raft.NodeHost, error) {
 		EnableMetrics:       true,
 		MaxReceiveQueueSize: e.cfg.MaxReceiveQueueSize,
 		MaxSendQueueSize:    e.cfg.MaxSendQueueSize,
+		QUICUDPBufferSize:   e.cfg.QUICUDPBufferSize,
 		SystemEventListener: e.events,
 		RaftEventListener:   e.events,
 	}

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -930,16 +930,17 @@ func newTestConfig() Config {
 	raftPort := getTestPort()
 	gossipPort := getTestPort()
 	return Config{
-		NodeID:         1,
-		InitialMembers: map[uint64]string{1: fmt.Sprintf("127.0.0.1:%d", raftPort)},
-		WALDir:         "/wal",
-		NodeHostDir:    "/nh",
-		RTTMillisecond: 5,
-		RaftAddress:    fmt.Sprintf("127.0.0.1:%d", raftPort),
-		Gossip:         GossipConfig{BindAddress: fmt.Sprintf("127.0.0.1:%d", gossipPort), InitialMembers: []string{fmt.Sprintf("127.0.0.1:%d", gossipPort)}},
-		Table:          TableConfig{FS: pebble.NewPebbleFS(fs), TableCacheSize: 1024, ElectionRTT: 10, HeartbeatRTT: 1},
-		Meta:           MetaConfig{ElectionRTT: 10, HeartbeatRTT: 1},
-		FS:             fs,
+		NodeID:            1,
+		InitialMembers:    map[uint64]string{1: fmt.Sprintf("127.0.0.1:%d", raftPort)},
+		WALDir:            "/wal",
+		NodeHostDir:       "/nh",
+		RTTMillisecond:    5,
+		RaftAddress:       fmt.Sprintf("127.0.0.1:%d", raftPort),
+		QUICUDPBufferSize: 4 * 1024 * 1024, // 4 MiB — fits within most CI kernel limits
+		Gossip:            GossipConfig{BindAddress: fmt.Sprintf("127.0.0.1:%d", gossipPort), InitialMembers: []string{fmt.Sprintf("127.0.0.1:%d", gossipPort)}},
+		Table:             TableConfig{FS: pebble.NewPebbleFS(fs), TableCacheSize: 1024, ElectionRTT: 10, HeartbeatRTT: 1},
+		Meta:              MetaConfig{ElectionRTT: 10, HeartbeatRTT: 1},
+		FS:                fs,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a configurable UDP socket buffer size for the QUIC transport layer, allowing users to cap the buffer size to avoid log warnings on systems with low kernel limits (such as CI environments). The change adds the `QUICUDPBufferSize` field to configuration structs, exposes it as a command-line flag, ensures it is correctly propagated throughout the codebase, and implements logic to cap buffer size requests in the QUIC transport. Default test configurations are updated to use a 4 MiB buffer.

The most important changes are:

### QUIC UDP Buffer Size Configuration

* Added a `QUICUDPBufferSize` field to the main configuration structs (`storage.Config`, `raft/config.NodeHostConfig`) to specify the UDP socket receive/send buffer size for the QUIC transport. When set, this value caps buffer size requests, preventing noisy log warnings on systems with low kernel limits. [[1]](diffhunk://#diff-c89cdc9386ddbc90f279850604adc49e4bcb2d3782e77a928b0ebd05a8966b99R84-R89) [[2]](diffhunk://#diff-b6a687443d11d888b480c1b760a07883e89ed9abb1d7a43f8f4da79a11f025b7R332-R341)
* Introduced the `--raft.quic-udp-buffer-size` command-line flag to allow users to configure this value.

### Propagation and Usage

* Ensured the `QUICUDPBufferSize` value is correctly passed through server setup and engine creation, so it is used by the QUIC transport layer. [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R63) [[2]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R302)
* In the QUIC transport implementation, wrapped the UDP connection with logic to cap buffer size requests (`cappedUDPConn`), ensuring the QUIC library does not request buffers larger than allowed. [[1]](diffhunk://#diff-c065dd6c38e6e18ffefe6aaafc160422f517d6cc1d730eaa41405774fa0ef14cL256-R271) [[2]](diffhunk://#diff-c065dd6c38e6e18ffefe6aaafc160422f517d6cc1d730eaa41405774fa0ef14cR596-R626)

### Testing and CI

* Updated test engine and backup configurations to use a 4 MiB buffer, which fits within most CI kernel limits, improving test reliability. [[1]](diffhunk://#diff-517f48c6e2b26fb361ff037fa6cddede11e4f540e307e4c90b0b2e92a005529bR67) [[2]](diffhunk://#diff-3021c116bf4095233ac538f7288dc8f4b060453b8d6c7286b22af0cd1839aeb3R324) [[3]](diffhunk://#diff-d944e219b37d014e1563b61666b9f972935602985b3bbd39a9838189c0983da7R218) [[4]](diffhunk://#diff-d944e219b37d014e1563b61666b9f972935602985b3bbd39a9838189c0983da7R238) [[5]](diffhunk://#diff-6e1b2194882893051a23d718f236845db678bd1858aa5bd4d042f01ca11de1deR939)
* Set `fail-fast: false` in the GitHub Actions test matrix to ensure all test jobs run to completion even if one fails.