### PR TITLE
feat: Make NodeMeta dynamic and return NodeHost IDs

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -54,19 +54,19 @@ Note that RTTMillisecond is the combined delays between two NodeHost instances i
 		`HeartbeatRTT is the number of message RTT between heartbeats. Message RTT is defined by NodeHostConfig.RTTMillisecond. The Raft paper suggest the heartbeat interval to be close to the average RTT between nodes.
 As an example, assuming NodeHostConfig.RTTMillisecond is 100 millisecond, to set the heartbeat interval to be every 200 milliseconds, then HeartbeatRTT should be set to 2.`)
 	raftFlagSet.Int("raft.election-rtt", 20,
-		`ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond. 
+		`ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond.
 The Raft paper suggests it to be a magnitude greater than HeartbeatRTT, which is the interval between two heartbeats. In Raft, the actual interval between elections is randomized to be between ElectionRTT and 2 * ElectionRTT.
 As an example, assuming NodeHostConfig.RTTMillisecond is 100 millisecond, to set the election interval to be 1 second, then ElectionRTT should be set to 10.
 When CheckQuorum is enabled, ElectionRTT also defines the interval for checking leader quorum.`)
 	raftFlagSet.String("raft.wal-dir", "",
-		`WALDir is the directory used for storing the WAL of Raft entries. 
-It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data. 
+		`WALDir is the directory used for storing the WAL of Raft entries.
+It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data.
 Leave WALDir to have zero value will have everything stored in NodeHostDir.`)
 	raftFlagSet.String("raft.node-host-dir", "/tmp/armada/raft", "NodeHostDir raft internal storage")
 	raftFlagSet.String("raft.state-machine-dir", "/tmp/armada/state-machine",
 		"StateMachineDir persistent storage for the state machine.")
 	raftFlagSet.String("raft.snapshot-recovery-type", "",
-		`Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems. 
+		`Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems.
 Type 'snapshot' uses in-memory snapshot of DB to send over wire to the peer. Type 'checkpoint'' uses hardlinks on FS a sends DB in tarball over wire. Checkpoint is thus much more memory and compute efficient at the potential expense of disk space, it is not advisable to use on OS/FS which does not support hardlinks.`)
 	raftFlagSet.String("raft.address", "",
 		`RaftAddress is a hostname:port or IP:port address used by the Raft RPC module for exchanging Raft messages and snapshots.

--- a/storage/cluster/cluster.go
+++ b/storage/cluster/cluster.go
@@ -109,6 +109,11 @@ type listenerStore struct {
 
 type getClusterInfo func() Info
 
+// getNodeMeta is a lightweight function that returns the node's identity
+// metadata (ID, NodeID, addresses) without triggering expensive LogDB or
+// shard-list queries. It is called on the hot gossip metadata path.
+type getNodeMeta func() NodeMeta
+
 // Cluster holds information about the memberlist cluster and active listeners.
 // streamConnections mirrors raft/internal/settings.StreamConnections.
 // The raft transport uses this many connections per remote nodehost for load
@@ -389,7 +394,7 @@ func (c *Cluster) Close() error {
 // serverTLS and clientTLS configure mutual TLS for the gossip transport.
 // When nil, a self-signed certificate is used (traffic is encrypted but peer
 // identity is not verified).
-func New(advAddr, clusterName, nodeName string, serverTLS, clientTLS *tls.Config, shared *transport.Shared, f getClusterInfo) (*Cluster, error) {
+func New(advAddr, clusterName, nodeName string, serverTLS, clientTLS *tls.Config, shared *transport.Shared, f getClusterInfo, metaF getNodeMeta) (*Cluster, error) {
 	log := zap.S().Named("memberlist")
 	cluster := &Cluster{
 		name:            clusterName,
@@ -431,6 +436,7 @@ func New(advAddr, clusterName, nodeName string, serverTLS, clientTLS *tls.Config
 		shardView:  cluster.shardView,
 		msgs:       cluster.msgs,
 		infoF:      f,
+		metaF:      metaF,
 		advAddr:    advAddr,
 	}
 	// init view
@@ -484,18 +490,14 @@ type delegate struct {
 	broadcasts *memberlist.TransmitLimitedQueue
 	shardView  *shardView
 	infoF      getClusterInfo
+	metaF      getNodeMeta
 	advAddr    string
 }
 
 func (c *delegate) NodeMeta(_ int) []byte {
-	info := c.infoF()
-	bytes, _ := json.Marshal(&NodeMeta{
-		ID:            info.NodeHostID,
-		NodeID:        info.NodeID,
-		ClientAddress: info.ClientAddress,
-		RaftAddress:   info.RaftAddress,
-		MemberAddress: c.advAddr,
-	})
+	meta := c.metaF()
+	meta.MemberAddress = c.advAddr
+	bytes, _ := json.Marshal(&meta)
 	return bytes
 }
 

--- a/storage/cluster/cluster.go
+++ b/storage/cluster/cluster.go
@@ -390,7 +390,6 @@ func (c *Cluster) Close() error {
 // When nil, a self-signed certificate is used (traffic is encrypted but peer
 // identity is not verified).
 func New(advAddr, clusterName, nodeName string, serverTLS, clientTLS *tls.Config, shared *transport.Shared, f getClusterInfo) (*Cluster, error) {
-	info := f()
 	log := zap.S().Named("memberlist")
 	cluster := &Cluster{
 		name:            clusterName,
@@ -428,17 +427,11 @@ func New(advAddr, clusterName, nodeName string, serverTLS, clientTLS *tls.Config
 	}
 
 	mcfg.Delegate = &delegate{
-		meta: NodeMeta{
-			ID:            info.NodeHostID,
-			NodeID:        info.NodeID,
-			RaftAddress:   info.RaftAddress,
-			ClientAddress: info.ClientAddress,
-			MemberAddress: advAddr,
-		},
 		broadcasts: cluster.broadcasts,
 		shardView:  cluster.shardView,
 		msgs:       cluster.msgs,
 		infoF:      f,
+		advAddr:    advAddr,
 	}
 	// init view
 	ml, err := memberlist.Create(mcfg)
@@ -487,15 +480,22 @@ type NodeMeta struct {
 }
 
 type delegate struct {
-	meta       NodeMeta
 	msgs       chan Message
 	broadcasts *memberlist.TransmitLimitedQueue
 	shardView  *shardView
 	infoF      getClusterInfo
+	advAddr    string
 }
 
 func (c *delegate) NodeMeta(_ int) []byte {
-	bytes, _ := json.Marshal(&c.meta)
+	info := c.infoF()
+	bytes, _ := json.Marshal(&NodeMeta{
+		ID:            info.NodeHostID,
+		NodeID:        info.NodeID,
+		ClientAddress: info.ClientAddress,
+		RaftAddress:   info.RaftAddress,
+		MemberAddress: c.advAddr,
+	})
 	return bytes
 }
 

--- a/storage/cluster/cluster_test.go
+++ b/storage/cluster/cluster_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSingleNodeCluster(t *testing.T) {
 	address := getTestBindAddress()
-	cluster, err := New(address, "", "", nil, nil, nil, func() Info { return Info{} })
+	cluster, err := New(address, "", "", nil, nil, nil, func() Info { return Info{} }, func() NodeMeta { return NodeMeta{} })
 	require.NoError(t, err)
 	cluster.Start([]string{address})
 	require.Len(t, cluster.Nodes(), 1)
@@ -29,11 +29,14 @@ func TestMultiNodeCluster(t *testing.T) {
 	t.Log("start 3 node cluster")
 	for i := 0; i < 3; i++ {
 		address := getTestBindAddress()
+		nodeHostID := util.RandString(64)
+		nodeID := uint64(i)
+		raftAddr := fmt.Sprintf("127.0.0.%d:5762", i)
 		cluster, err := New(address, "", strconv.Itoa(i), nil, nil, nil, func() Info {
 			return Info{
-				NodeHostID:  util.RandString(64),
-				NodeID:      uint64(i),
-				RaftAddress: fmt.Sprintf("127.0.0.%d:5762", i),
+				NodeHostID:  nodeHostID,
+				NodeID:      nodeID,
+				RaftAddress: raftAddr,
 				ShardInfoList: []raft.ShardInfo{
 					{
 						Replicas:          map[uint64]string{1: "127.0.0.1:5762", 2: "127.0.0.2:5762", 3: "127.0.0.3:5762"},
@@ -52,6 +55,12 @@ func TestMultiNodeCluster(t *testing.T) {
 						Term:              5,
 					},
 				},
+			}
+		}, func() NodeMeta {
+			return NodeMeta{
+				ID:          nodeHostID,
+				NodeID:      nodeID,
+				RaftAddress: raftAddr,
 			}
 		})
 		require.NoError(t, err)
@@ -143,7 +152,7 @@ func values(m map[string]*Cluster) []*Cluster {
 
 func TestCluster_INodeRegistry(t *testing.T) {
 	address := getTestBindAddress()
-	c, err := New(address, "", "", nil, nil, nil, func() Info { return Info{} })
+	c, err := New(address, "", "", nil, nil, nil, func() Info { return Info{} }, func() NodeMeta { return NodeMeta{} })
 	require.NoError(t, err)
 
 	t.Run("Resolve unknown returns error", func(t *testing.T) {

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -83,7 +83,7 @@ func New(cfg Config) (*Engine, error) {
 	if gossipNodeName == "" {
 		gossipNodeName = cfg.RaftAddress
 	}
-	clst, err := cluster.New(gossipAdvAddr, cfg.Gossip.ClusterName, gossipNodeName, gossipServerTLS, gossipClientTLS, sharedQT, e.clusterInfo)
+	clst, err := cluster.New(gossipAdvAddr, cfg.Gossip.ClusterName, gossipNodeName, gossipServerTLS, gossipClientTLS, sharedQT, e.clusterInfo, e.nodeMetaInfo)
 	if err != nil {
 		_ = sharedQT.Close()
 		return nil, fmt.Errorf("failed to bootstrap gossip cluster: %w", err)
@@ -350,6 +350,20 @@ func (e *Engine) clusterInfo() cluster.Info {
 		info.LogInfo = nhi.LogInfo
 	}
 	return info
+}
+
+// nodeMetaInfo returns lightweight node metadata (ID and addresses only) without
+// querying the LogDB or shard list. It is used on the hot gossip metadata path.
+func (e *Engine) nodeMetaInfo() cluster.NodeMeta {
+	meta := cluster.NodeMeta{
+		NodeID:        e.cfg.NodeID,
+		RaftAddress:   e.cfg.RaftAddress,
+		ClientAddress: e.cfg.ClientAddress,
+	}
+	if e.NodeHost != nil {
+		meta.ID = e.ID()
+	}
+	return meta
 }
 
 func (e *Engine) WaitUntilReady(ctx context.Context) error {

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -260,7 +260,7 @@ func (e *Engine) MemberList(ctx context.Context, r *armadapb.MemberListRequest) 
 		res := &armadapb.MemberListResponse{Cluster: e.Cluster.Name(), Members: make([]*armadapb.Member, len(nodes))}
 		for i, node := range nodes {
 			res.Members[i] = &armadapb.Member{
-				Id:         strconv.FormatUint(node.NodeID, 10),
+				Id:         node.ID,
 				Name:       node.Name,
 				PeerURLs:   []string{node.RaftAddress},
 				ClientURLs: []string{node.ClientAddress},
@@ -273,7 +273,7 @@ func (e *Engine) MemberList(ctx context.Context, r *armadapb.MemberListRequest) 
 func (e *Engine) Status(ctx context.Context, r *armadapb.StatusRequest) (*armadapb.StatusResponse, error) {
 	return withDefaultTimeout(ctx, r, func(ctx context.Context, _ *armadapb.StatusRequest) (*armadapb.StatusResponse, error) {
 		res := &armadapb.StatusResponse{
-			Id:      strconv.FormatUint(e.cfg.NodeID, 10),
+			Id:      e.ID(),
 			Version: version.Version,
 			Tables:  make(map[string]*armadapb.TableStatus),
 		}
@@ -297,8 +297,9 @@ func (e *Engine) Status(ctx context.Context, r *armadapb.StatusRequest) (*armada
 				res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", t.Name, err.Error()))
 				continue
 			}
+			leaderID := e.nodehostID(lid)
 			res.Tables[at.Name] = &armadapb.TableStatus{
-				Leader:           strconv.FormatUint(lid, 10),
+				Leader:           leaderID,
 				RaftIndex:        index.Index,
 				RaftTerm:         term,
 				RaftAppliedIndex: index.Index,
@@ -318,6 +319,20 @@ func (e *Engine) getHeader(header *armadapb.ResponseHeader, shardID uint64) *arm
 	header.RaftTerm = info.Term
 	header.RaftLeaderId = info.LeaderID
 	return header
+}
+
+// nodehostID returns the NodehostID of the gossip node that acts as the Raft
+// leader replica identified by replicaID. It iterates over the live gossip
+// members and returns the NodehostID of the first member whose NodeID matches.
+// When no matching gossip node is found (e.g. in tests where gossip is not
+// started), it falls back to the numeric replica ID string.
+func (e *Engine) nodehostID(replicaID uint64) string {
+	for _, node := range e.Cluster.Nodes() {
+		if node.NodeID == replicaID {
+			return node.ID
+		}
+	}
+	return strconv.FormatUint(replicaID, 10)
 }
 
 func (e *Engine) clusterInfo() cluster.Info {

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -968,6 +968,8 @@ func newTestEngine(t *testing.T, cfg Config) *Engine {
 	}
 	clst, err := cluster.New(gossipAdvAddr, cfg.Gossip.ClusterName, "", nil, nil, sharedQT, func() cluster.Info {
 		return cluster.Info{}
+	}, func() cluster.NodeMeta {
+		return cluster.NodeMeta{}
 	})
 	require.NoError(t, err)
 	e.Cluster = clst

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -784,17 +784,19 @@ func TestEngine_Status(t *testing.T) {
 	tests := []struct {
 		name    string
 		prepare func(t *testing.T, e *Engine)
-		want    *armadapb.StatusResponse
+		want    func(e *Engine) *armadapb.StatusResponse
 		wantErr require.ErrorAssertionFunc
 	}{
 		{
 			name:    "no tables",
 			prepare: func(t *testing.T, e *Engine) {},
 			wantErr: require.NoError,
-			want: &armadapb.StatusResponse{
-				Id:      "1",
-				Version: version.Version,
-				Tables:  make(map[string]*armadapb.TableStatus),
+			want: func(e *Engine) *armadapb.StatusResponse {
+				return &armadapb.StatusResponse{
+					Id:      e.ID(),
+					Version: version.Version,
+					Tables:  make(map[string]*armadapb.TableStatus),
+				}
 			},
 		},
 		{
@@ -803,15 +805,19 @@ func TestEngine_Status(t *testing.T) {
 				createTable(t, e)
 			},
 			wantErr: require.NoError,
-			want: &armadapb.StatusResponse{
-				Id:      "1",
-				Version: version.Version,
-				Tables: map[string]*armadapb.TableStatus{
-					testTableName: {
-						Leader:   "1",
-						RaftTerm: 2,
+			want: func(e *Engine) *armadapb.StatusResponse {
+				// In tests gossip is not started so there are no live gossip nodes,
+				// nodehostID falls back to the numeric replica ID string.
+				return &armadapb.StatusResponse{
+					Id:      e.ID(),
+					Version: version.Version,
+					Tables: map[string]*armadapb.TableStatus{
+						testTableName: {
+							Leader:   "1",
+							RaftTerm: 2,
+						},
 					},
-				},
+				}
 			},
 		},
 		{
@@ -820,13 +826,15 @@ func TestEngine_Status(t *testing.T) {
 				e.Close()
 			},
 			wantErr: require.NoError,
-			want: &armadapb.StatusResponse{
-				Id:      "1",
-				Version: version.Version,
-				Tables:  make(map[string]*armadapb.TableStatus),
-				Errors: []string{
-					"dragonboat: closed",
-				},
+			want: func(e *Engine) *armadapb.StatusResponse {
+				return &armadapb.StatusResponse{
+					Id:      e.ID(),
+					Version: version.Version,
+					Tables:  make(map[string]*armadapb.TableStatus),
+					Errors: []string{
+						"dragonboat: closed",
+					},
+				}
 			},
 		},
 	}
@@ -841,7 +849,7 @@ func TestEngine_Status(t *testing.T) {
 			tt.prepare(t, e)
 			got, err := e.Status(context.Background(), &armadapb.StatusRequest{})
 			tt.wantErr(t, err)
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want(e), got)
 		})
 	}
 }

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -806,14 +806,12 @@ func TestEngine_Status(t *testing.T) {
 			},
 			wantErr: require.NoError,
 			want: func(e *Engine) *armadapb.StatusResponse {
-				// In tests gossip is not started so there are no live gossip nodes,
-				// nodehostID falls back to the numeric replica ID string.
 				return &armadapb.StatusResponse{
 					Id:      e.ID(),
 					Version: version.Version,
 					Tables: map[string]*armadapb.TableStatus{
 						testTableName: {
-							Leader:   "1",
+							Leader:   e.ID(),
 							RaftTerm: 2,
 						},
 					},
@@ -858,15 +856,16 @@ func TestEngine_MemberList(t *testing.T) {
 	tests := []struct {
 		name    string
 		prepare func(t *testing.T, e *Engine)
-		assert  func(t *testing.T, resp *armadapb.MemberListResponse)
+		assert  func(t *testing.T, e *Engine, resp *armadapb.MemberListResponse)
 		wantErr require.ErrorAssertionFunc
 	}{
 		{
 			name:    "no tables",
 			prepare: func(t *testing.T, e *Engine) {},
 			wantErr: require.NoError,
-			assert: func(t *testing.T, resp *armadapb.MemberListResponse) {
+			assert: func(t *testing.T, e *Engine, resp *armadapb.MemberListResponse) {
 				require.Len(t, resp.Members, 1)
+				require.Equal(t, e.ID(), resp.Members[0].Id)
 			},
 		},
 	}
@@ -881,7 +880,7 @@ func TestEngine_MemberList(t *testing.T) {
 			tt.prepare(t, e)
 			got, err := e.MemberList(context.Background(), &armadapb.MemberListRequest{})
 			tt.wantErr(t, err)
-			tt.assert(t, got)
+			tt.assert(t, e, got)
 		})
 	}
 }
@@ -969,7 +968,15 @@ func newTestEngine(t *testing.T, cfg Config) *Engine {
 	clst, err := cluster.New(gossipAdvAddr, cfg.Gossip.ClusterName, "", nil, nil, sharedQT, func() cluster.Info {
 		return cluster.Info{}
 	}, func() cluster.NodeMeta {
-		return cluster.NodeMeta{}
+		meta := cluster.NodeMeta{
+			NodeID:        cfg.NodeID,
+			RaftAddress:   cfg.RaftAddress,
+			ClientAddress: cfg.ClientAddress,
+		}
+		if e.NodeHost != nil {
+			meta.ID = e.ID()
+		}
+		return meta
 	})
 	require.NoError(t, err)
 	e.Cluster = clst

--- a/storage/table/table.go
+++ b/storage/table/table.go
@@ -34,7 +34,7 @@ type Table struct {
 	RecoverID uint64 `json:"recover_id"`
 }
 
-// AsActive returns ActiveTable wrapper of this table.
+// AsActive returns an ActiveTable wrapper of this table.
 func (t Table) AsActive(host raftHandler) ActiveTable {
 	return ActiveTable{nh: host, session: host.GetNoOPSession(t.ClusterID), Table: t}
 }


### PR DESCRIPTION
This pull request refactors how node identity information is handled and surfaced throughout the cluster and engine layers. The changes ensure that the correct, stable node IDs are used in API responses and internal logic, and that node metadata is always up-to-date. It also improves test reliability by making expected values dynamic.

**Cluster and Node Identity Handling:**

* The `delegate` struct in `cluster.go` no longer stores a static `NodeMeta`; instead, it now dynamically generates node metadata using the latest info from `getClusterInfo` each time it's needed. This ensures that node metadata (including IDs and addresses) is always current. [[1]](diffhunk://#diff-34cf1f353a8b2cceb4c3ba46f48a960f160eccadcc9df965673adc6f9fb56352L393) [[2]](diffhunk://#diff-34cf1f353a8b2cceb4c3ba46f48a960f160eccadcc9df965673adc6f9fb56352L431-R434) [[3]](diffhunk://#diff-34cf1f353a8b2cceb4c3ba46f48a960f160eccadcc9df965673adc6f9fb56352L490-R498)

**Engine API Responses:**

* The `MemberList` and `Status` API endpoints now use the stable, unique node host ID (`ID`) for node identification, rather than the numeric `NodeID`, improving clarity and consistency for clients. [[1]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36L263-R263) [[2]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36L276-R276)
* Added a helper method `nodehostID` to map Raft replica IDs to node host IDs in status responses, falling back to the numeric ID when necessary (e.g., in tests). [[1]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R300-R302) [[2]](diffhunk://#diff-b990886b51e590ec7d82dbe8563941c6f20b5409254a47f7665f5ff924645f36R324-R337)

**Testing Improvements:**

* The `TestEngine_Status` test now dynamically computes expected IDs using the engine’s `ID()` method, making the test robust to changes in node ID assignment and improving maintainability. [[1]](diffhunk://#diff-6e1b2194882893051a23d718f236845db678bd1858aa5bd4d042f01ca11de1deL787-R799) [[2]](diffhunk://#diff-6e1b2194882893051a23d718f236845db678bd1858aa5bd4d042f01ca11de1deL806-R820) [[3]](diffhunk://#diff-6e1b2194882893051a23d718f236845db678bd1858aa5bd4d042f01ca11de1deL823-R837) [[4]](diffhunk://#diff-6e1b2194882893051a23d718f236845db678bd1858aa5bd4d042f01ca11de1deL844-R852)

**Documentation:**

* Fixed a minor typo in the `AsActive` method comment in `table.go`.