### PR TITLE
docs: netlify build hook

### DIFF
--- a/.github/workflows/notify-netlify.yml
+++ b/.github/workflows/notify-netlify.yml
@@ -1,0 +1,18 @@
+name: Notify Netlify
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - "docs/**"
+  release:
+    types:
+    - published
+
+jobs:
+  trigger-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Netlify build
+      run: curl -s -X POST ${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate notifications to Netlify when documentation changes are pushed to the `master` branch or when a new release is published.

**Automation and deployment:**

* Added `.github/workflows/notify-netlify.yml` to trigger a Netlify build via a webhook whenever files in the `docs/` directory are updated on the `master` branch or when a release is published.