### PR TITLE
Feat/snapshots v2

### DIFF
--- a/.github/workflows/notify-netlify.yml
+++ b/.github/workflows/notify-netlify.yml
@@ -3,16 +3,16 @@ name: Notify Netlify
 on:
   push:
     branches:
-    - master
+      - master
     paths:
-    - "docs/**"
+      - "docs/**"
   release:
     types:
-    - published
+      - published
 
 jobs:
   trigger-build:
     runs-on: ubuntu-latest
     steps:
-    - name: Trigger Netlify build
-      run: curl -s -X POST ${{ secrets.NETLIFY_BUILD_HOOK }}
+      - name: Trigger Netlify build
+        run: curl -s -X POST ${{ secrets.NETLIFY_BUILD_HOOK }}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,15 +12,16 @@ import (
 )
 
 var (
-	rootFlagSet         = pflag.NewFlagSet("root", pflag.ContinueOnError)
-	apiFlagSet          = pflag.NewFlagSet("api", pflag.ContinueOnError)
-	restFlagSet         = pflag.NewFlagSet("rest", pflag.ContinueOnError)
-	raftFlagSet         = pflag.NewFlagSet("raft", pflag.ContinueOnError)
-	memberlistFlagSet   = pflag.NewFlagSet("memberlist", pflag.ContinueOnError)
-	storageFlagSet      = pflag.NewFlagSet("storage", pflag.ContinueOnError)
-	maintenanceFlagSet  = pflag.NewFlagSet("maintenance", pflag.ContinueOnError)
-	tablesFlagSet       = pflag.NewFlagSet("tables", pflag.ContinueOnError)
-	experimentalFlagSet = pflag.NewFlagSet("experimental", pflag.ContinueOnError)
+	rootFlagSet          = pflag.NewFlagSet("root", pflag.ContinueOnError)
+	apiFlagSet           = pflag.NewFlagSet("api", pflag.ContinueOnError)
+	restFlagSet          = pflag.NewFlagSet("rest", pflag.ContinueOnError)
+	raftFlagSet          = pflag.NewFlagSet("raft", pflag.ContinueOnError)
+	memberlistFlagSet    = pflag.NewFlagSet("memberlist", pflag.ContinueOnError)
+	storageFlagSet       = pflag.NewFlagSet("storage", pflag.ContinueOnError)
+	maintenanceFlagSet   = pflag.NewFlagSet("maintenance", pflag.ContinueOnError)
+	tablesFlagSet        = pflag.NewFlagSet("tables", pflag.ContinueOnError)
+	experimentalFlagSet  = pflag.NewFlagSet("experimental", pflag.ContinueOnError)
+	snapshotStoreFlagSet = pflag.NewFlagSet("snapshotStore", pflag.ContinueOnError)
 )
 
 func init() {
@@ -126,6 +127,24 @@ All nodes of the cluster MUST set this to the same value. If changing it is advi
 	// Tables flags
 	tablesFlagSet.Bool("tables.enabled", true, "Whether tables API is enabled.")
 	tablesFlagSet.String("tables.token", "", "Token to check for tables API access, if left empty (default) no token is checked.")
+
+	// Snapshot store flags (leader-side shared-storage snapshot export – proposal 005).
+	snapshotStoreFlagSet.String("replication.snapshot-store.backend", "none",
+		`Blob store backend used for leader-side snapshot export (proposal 005).
+Supported values: none (disabled), filesystem.
+When set to "filesystem" the replication.snapshot-store.config field must supply the store configuration (YAML).`)
+	snapshotStoreFlagSet.String("replication.snapshot-store.config", "",
+		"YAML configuration block for the selected snapshot-store backend (see backend-specific docs).")
+	snapshotStoreFlagSet.Duration("replication.snapshot-store.full-interval", 6*time.Hour,
+		"How often a full snapshot is exported to the shared store for each table.")
+	snapshotStoreFlagSet.Duration("replication.snapshot-store.incr-interval", 30*time.Minute,
+		"How often an incremental snapshot is exported to the shared store for each table.")
+	snapshotStoreFlagSet.Int("replication.snapshot-store.incr-max-chain", 8,
+		"Maximum number of consecutive incremental artefacts before a new full snapshot must be taken.")
+	snapshotStoreFlagSet.Duration("replication.snapshot-store.retention", 48*time.Hour,
+		"Maximum age of snapshot artefacts in the shared store. Older artefacts are eligible for GC.")
+	snapshotStoreFlagSet.Duration("replication.snapshot-store.gc-interval", time.Hour,
+		"How often the GC worker runs to delete expired artefacts from the shared store.")
 }
 
 func initConfig(set *pflag.FlagSet) {

--- a/cmd/leader.go
+++ b/cmd/leader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/armadakv/armada/armadapb"
 	"github.com/armadakv/armada/armadaserver"
+	"github.com/armadakv/armada/replication/store"
 	"github.com/armadakv/armada/security"
 	serrors "github.com/armadakv/armada/storage/errors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -32,6 +33,7 @@ func init() {
 	leaderCmd.PersistentFlags().AddFlagSet(maintenanceFlagSet)
 	leaderCmd.PersistentFlags().AddFlagSet(tablesFlagSet)
 	leaderCmd.PersistentFlags().AddFlagSet(experimentalFlagSet)
+	leaderCmd.PersistentFlags().AddFlagSet(snapshotStoreFlagSet)
 
 	// Tables flags
 	leaderCmd.PersistentFlags().StringSlice("tables.names", nil, "Create Armada tables with given names.")
@@ -115,6 +117,29 @@ func leader(_ *cobra.Command, _ []string) error {
 			}
 		}
 	}()
+
+	// Start snapshot exporter and GC worker when a non-none backend is configured.
+	snapshotCtx, cancelSnapshot := context.WithCancel(context.Background())
+	defer cancelSnapshot()
+	if backend := viper.GetString("replication.snapshot-store.backend"); backend != "" && backend != "none" {
+		bkt, err := newSnapshotBucket(backend, viper.GetString("replication.snapshot-store.config"))
+		if err != nil {
+			return fmt.Errorf("snapshot-store: %w", err)
+		}
+		// Use the Raft address as a human-readable, cluster-unique node identifier
+		// in snapshot meta files. There is no separate node-id config option.
+		nodeAddress := viper.GetString("raft.address")
+
+		exp := store.NewSnapshotExporter(
+			engine,
+			snapshotExporterConfig(nodeAddress, bkt),
+			logger.Sugar(),
+		)
+		go exp.Run(snapshotCtx)
+
+		gc := store.NewGCWorker(snapshotGCConfig(bkt), logger.Sugar())
+		go gc.Run(snapshotCtx)
+	}
 
 	// Start servers
 	{

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -1,0 +1,50 @@
+// Copyright JAMF Software, LLC
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/armadakv/armada/replication/store"
+	"github.com/spf13/viper"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
+)
+
+// newSnapshotBucket creates an objstore.Bucket from the snapshot-store configuration.
+// Returns (nil, nil) when backend is "none" (feature disabled).
+func newSnapshotBucket(backend, cfgYAML string) (objstore.Bucket, error) {
+	switch backend {
+	case "", "none":
+		return nil, nil
+	case "filesystem":
+		bkt, err := filesystem.NewBucketFromConfig([]byte(cfgYAML))
+		if err != nil {
+			return nil, fmt.Errorf("snapshot-store: create filesystem bucket: %w", err)
+		}
+		return bkt, nil
+	default:
+		return nil, fmt.Errorf("snapshot-store: unsupported backend %q (supported: none or empty string to disable, filesystem)", backend)
+	}
+}
+
+// snapshotExporterConfig reads the snapshot-store Viper configuration and returns
+// an ExporterConfig. bucket must not be nil (caller is responsible for the check).
+func snapshotExporterConfig(nodeID string, bucket objstore.Bucket) store.ExporterConfig {
+	return store.ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       nodeID,
+		FullInterval: viper.GetDuration("replication.snapshot-store.full-interval"),
+		IncrInterval: viper.GetDuration("replication.snapshot-store.incr-interval"),
+		IncrMaxChain: viper.GetInt("replication.snapshot-store.incr-max-chain"),
+	}
+}
+
+// snapshotGCConfig reads the snapshot-store GC Viper configuration.
+func snapshotGCConfig(bucket objstore.Bucket) store.GCConfig {
+	return store.GCConfig{
+		Bucket:    bucket,
+		Retention: viper.GetDuration("replication.snapshot-store.retention"),
+		Interval:  viper.GetDuration("replication.snapshot-store.gc-interval"),
+	}
+}

--- a/cmd/snapshot_test.go
+++ b/cmd/snapshot_test.go
@@ -1,0 +1,74 @@
+// Copyright JAMF Software, LLC
+
+package cmd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+func TestNewSnapshotBucket_None(t *testing.T) {
+	bkt, err := newSnapshotBucket("none", "")
+	require.NoError(t, err)
+	assert.Nil(t, bkt, "none backend should return nil bucket")
+
+	bkt, err = newSnapshotBucket("", "")
+	require.NoError(t, err)
+	assert.Nil(t, bkt, "empty backend should return nil bucket")
+}
+
+func TestNewSnapshotBucket_Unsupported(t *testing.T) {
+	_, err := newSnapshotBucket("s3", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported backend")
+}
+
+func TestNewSnapshotBucket_Filesystem(t *testing.T) {
+	dir := t.TempDir()
+	cfg := "directory: " + dir
+	bkt, err := newSnapshotBucket("filesystem", cfg)
+	require.NoError(t, err)
+	require.NotNil(t, bkt)
+
+	// Verify it's a usable bucket.
+	_, ok := bkt.(objstore.Bucket)
+	assert.True(t, ok)
+}
+
+func TestNewSnapshotBucket_FilesystemMissingDirectory(t *testing.T) {
+	_, err := newSnapshotBucket("filesystem", "")
+	require.Error(t, err)
+}
+
+func TestSnapshotExporterConfig_Defaults(t *testing.T) {
+	// Reset viper state, populate defaults (using flag defaults).
+	initConfig(leaderCmd.PersistentFlags())
+
+	cfg := snapshotExporterConfig("node-1", nil)
+	assert.Equal(t, "node-1", cfg.NodeID)
+	assert.Equal(t, 6*time.Hour, cfg.FullInterval)
+	assert.Equal(t, 30*time.Minute, cfg.IncrInterval)
+	assert.Equal(t, 8, cfg.IncrMaxChain)
+}
+
+func TestSnapshotGCConfig_Defaults(t *testing.T) {
+	initConfig(leaderCmd.PersistentFlags())
+
+	cfg := snapshotGCConfig(nil)
+	assert.Equal(t, 48*time.Hour, cfg.Retention)
+	assert.Equal(t, time.Hour, cfg.Interval)
+}
+
+func init() {
+	// Ensure the leader command flags are registered before the tests run.
+	// This is normally done by the init() in leader.go but may not happen
+	// in test binaries so we guard with an env var to avoid double-registration.
+	if os.Getenv("SKIP_LEADER_INIT") == "" {
+		os.Setenv("SKIP_LEADER_INIT", "1")
+	}
+}

--- a/cmd/snapshot_test.go
+++ b/cmd/snapshot_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
 )
 
 func TestNewSnapshotBucket_None(t *testing.T) {
@@ -34,10 +33,6 @@ func TestNewSnapshotBucket_Filesystem(t *testing.T) {
 	bkt, err := newSnapshotBucket("filesystem", cfg)
 	require.NoError(t, err)
 	require.NotNil(t, bkt)
-
-	// Verify it's a usable bucket.
-	_, ok := bkt.(objstore.Bucket)
-	assert.True(t, ok)
 }
 
 func TestNewSnapshotBucket_FilesystemMissingDirectory(t *testing.T) {

--- a/docs/operations_guide/cli/armada_follower.md
+++ b/docs/operations_guide/cli/armada_follower.md
@@ -47,7 +47,7 @@ armada follower [flags]
                                                               This is also the identifier for a Storage instance. RaftAddress should be set to the public address that can be accessed from remote Storage instances.
       --raft.compaction-overhead uint                         CompactionOverhead defines the number of most recent entries to keep after each Raft log compaction.
                                                               Raft log compaction is performed automatically every time when a snapshot is created. (default 5000)
-      --raft.election-rtt int                                 ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond. 
+      --raft.election-rtt int                                 ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond.
                                                               The Raft paper suggests it to be a magnitude greater than HeartbeatRTT, which is the interval between two heartbeats. In Raft, the actual interval between elections is randomized to be between ElectionRTT and 2 * ElectionRTT.
                                                               As an example, assuming NodeHostConfig.RTTMillisecond is 100 millisecond, to set the election interval to be 1 second, then ElectionRTT should be set to 10.
                                                               When CheckQuorum is enabled, ElectionRTT also defines the interval for checking leader quorum. (default 20)
@@ -76,14 +76,14 @@ armada follower [flags]
       --raft.snapshot-entries uint                            SnapshotEntries defines how often the state machine should be snapshot automatically.
                                                               It is defined in terms of the number of applied Raft log entries.
                                                               SnapshotEntries can be set to 0 to disable such automatic snapshotting. (default 10000)
-      --raft.snapshot-recovery-type string                    Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems. 
+      --raft.snapshot-recovery-type string                    Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems.
                                                               Type 'snapshot' uses in-memory snapshot of DB to send over wire to the peer. Type 'checkpoint'' uses hardlinks on FS a sends DB in tarball over wire. Checkpoint is thus much more memory and compute efficient at the potential expense of disk space, it is not advisable to use on OS/FS which does not support hardlinks.
       --raft.state-machine-dir string                         StateMachineDir persistent storage for the state machine. (default "/tmp/armada/state-machine")
       --raft.tls-ca-file string                               Path to the CA certificate file used to verify raft peer certificates.
       --raft.tls-cert-file string                             Path to the TLS certificate file for mutual TLS between raft peers. Must be set together with raft.tls-key-file and raft.tls-ca-file.
       --raft.tls-key-file string                              Path to the TLS private key file for mutual TLS between raft peers.
-      --raft.wal-dir string                                   WALDir is the directory used for storing the WAL of Raft entries. 
-                                                              It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data. 
+      --raft.wal-dir string                                   WALDir is the directory used for storing the WAL of Raft entries.
+                                                              It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data.
                                                               Leave WALDir to have zero value will have everything stored in NodeHostDir.
       --replication.ca-filename string                        Path to the client CA cert file. The CA file is used to verify server authority. (default "hack/replication/ca.crt")
       --replication.cert-filename string                      Path to the client certificate. (default "hack/replication/client.crt")

--- a/docs/operations_guide/cli/armada_leader.md
+++ b/docs/operations_guide/cli/armada_leader.md
@@ -47,7 +47,7 @@ armada leader [flags]
                                                                This is also the identifier for a Storage instance. RaftAddress should be set to the public address that can be accessed from remote Storage instances.
       --raft.compaction-overhead uint                          CompactionOverhead defines the number of most recent entries to keep after each Raft log compaction.
                                                                Raft log compaction is performed automatically every time when a snapshot is created. (default 5000)
-      --raft.election-rtt int                                  ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond. 
+      --raft.election-rtt int                                  ElectionRTT is the minimum number of message RTT between elections. Message RTT is defined by NodeHostConfig.RTTMillisecond.
                                                                The Raft paper suggests it to be a magnitude greater than HeartbeatRTT, which is the interval between two heartbeats. In Raft, the actual interval between elections is randomized to be between ElectionRTT and 2 * ElectionRTT.
                                                                As an example, assuming NodeHostConfig.RTTMillisecond is 100 millisecond, to set the election interval to be 1 second, then ElectionRTT should be set to 10.
                                                                When CheckQuorum is enabled, ElectionRTT also defines the interval for checking leader quorum. (default 20)
@@ -76,14 +76,14 @@ armada leader [flags]
       --raft.snapshot-entries uint                             SnapshotEntries defines how often the state machine should be snapshot automatically.
                                                                It is defined in terms of the number of applied Raft log entries.
                                                                SnapshotEntries can be set to 0 to disable such automatic snapshotting. (default 10000)
-      --raft.snapshot-recovery-type string                     Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems. 
+      --raft.snapshot-recovery-type string                     Specifies the way how the snapshots should be shared between nodes within the cluster. Options: snapshot, checkpoint, default: checkpoint for non Windows systems.
                                                                Type 'snapshot' uses in-memory snapshot of DB to send over wire to the peer. Type 'checkpoint'' uses hardlinks on FS a sends DB in tarball over wire. Checkpoint is thus much more memory and compute efficient at the potential expense of disk space, it is not advisable to use on OS/FS which does not support hardlinks.
       --raft.state-machine-dir string                          StateMachineDir persistent storage for the state machine. (default "/tmp/armada/state-machine")
       --raft.tls-ca-file string                                Path to the CA certificate file used to verify raft peer certificates.
       --raft.tls-cert-file string                              Path to the TLS certificate file for mutual TLS between raft peers. Must be set together with raft.tls-key-file and raft.tls-ca-file.
       --raft.tls-key-file string                               Path to the TLS private key file for mutual TLS between raft peers.
-      --raft.wal-dir string                                    WALDir is the directory used for storing the WAL of Raft entries. 
-                                                               It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data. 
+      --raft.wal-dir string                                    WALDir is the directory used for storing the WAL of Raft entries.
+                                                               It is recommended to use low latency storage such as NVME SSD with power loss protection to store such WAL data.
                                                                Leave WALDir to have zero value will have everything stored in NodeHostDir.
       --replication.address string                             Replication API server address. The address the server listens on. (default "http://0.0.0.0:8444")
       --replication.ca-filename string                         Path to the API server CA cert file.
@@ -93,6 +93,15 @@ armada leader [flags]
       --replication.key-filename string                        Path to the API server private key file.
       --replication.max-send-message-size-bytes uint           The target maximum size of single replication message allowed to send.
                                                                Under some circumstances, a larger message could be sent. Followers should be able to accept slightly larger messages. (default 4194304)
+      --replication.snapshot-store.backend string              Blob store backend used for leader-side snapshot export (proposal 005).
+                                                               Supported values: none (disabled), filesystem.
+                                                               When set to "filesystem" the replication.snapshot-store.config field must supply the store configuration (YAML). (default "none")
+      --replication.snapshot-store.config string               YAML configuration block for the selected snapshot-store backend (see backend-specific docs).
+      --replication.snapshot-store.full-interval duration      How often a full snapshot is exported to the shared store for each table. (default 6h0m0s)
+      --replication.snapshot-store.gc-interval duration        How often the GC worker runs to delete expired artefacts from the shared store. (default 1h0m0s)
+      --replication.snapshot-store.incr-interval duration      How often an incremental snapshot is exported to the shared store for each table. (default 30m0s)
+      --replication.snapshot-store.incr-max-chain int          Maximum number of consecutive incremental artefacts before a new full snapshot must be taken. (default 8)
+      --replication.snapshot-store.retention duration          Maximum age of snapshot artefacts in the shared store. Older artefacts are eligible for GC. (default 48h0m0s)
       --rest.address string                                    REST API server address. (default "http://127.0.0.1:8079")
       --rest.read-timeout duration                             Maximum duration for reading the entire request. (default 5s)
       --storage.block-cache-size int                           Shared block cache size in bytes, the cache is used to hold uncompressed blocks of data in memory. (default 16777216)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/thanos-io/objstore v0.0.0-20250813080715-4e5fd4289b50
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.28.0
@@ -43,7 +44,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
@@ -65,9 +65,12 @@ require (
 	github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/efficientgo/core v1.0.0-rc.0.0.20221201130417-ba593f67d2a4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/getsentry/sentry-go v0.46.2 // indirect
+	github.com/go-kit/log v0.2.1 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -124,6 +127,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.118.1 h1:b8RATMcrK9A4BH0rj8yQupPXp+aP+cJ0l6H7V9osV1E=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -84,6 +85,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/efficientgo/core v1.0.0-rc.0.0.20221201130417-ba593f67d2a4 h1:rydBwnBoywKQMjWF0z8SriYtQ+uUcaFsxuijMjJr5PI=
+github.com/efficientgo/core v1.0.0-rc.0.0.20221201130417-ba593f67d2a4/go.mod h1:kQa0V74HNYMfuJH6jiPiwNdpWXl4xd/K4tzlrcvYDQI=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -99,9 +102,13 @@ github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3Bop
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -319,6 +326,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/thanos-io/objstore v0.0.0-20250813080715-4e5fd4289b50 h1:LQ/cJudNo7b1g6WhJmt6vl4TaIhi8GqyyANlnow4rmQ=
+github.com/thanos-io/objstore v0.0.0-20250813080715-4e5fd4289b50/go.mod h1:47A17iRctHuA2KF73MSbOb7XELVyECduETzQAplRXNI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
@@ -457,6 +466,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pebble/pebble.go
+++ b/pebble/pebble.go
@@ -42,6 +42,7 @@ func split(b []byte) int {
 
 func DefaultOptions() *pebble.Options {
 	opts := &pebble.Options{
+		DisableWAL:                  true,
 		FormatMajorVersion:          pebble.FormatValueSeparation,
 		L0CompactionFileThreshold:   l0FileNumCompactionTrigger,
 		L0StopWritesThreshold:       l0StopWritesTrigger,

--- a/replication/store/exporter.go
+++ b/replication/store/exporter.go
@@ -1,0 +1,505 @@
+// Copyright JAMF Software, LLC
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/armadakv/armada/armadapb"
+	"github.com/armadakv/armada/replication/snapshot"
+	"github.com/armadakv/armada/storage/table"
+	"github.com/armadakv/armada/storage/table/fsm"
+	"github.com/thanos-io/objstore"
+	"go.uber.org/zap"
+)
+
+// SnapshotTable is the subset of table.ActiveTable used by SnapshotExporter.
+// Using an interface here allows tests to inject fakes without spinning up a
+// real Dragonboat node.
+type SnapshotTable interface {
+	Snapshot(ctx context.Context, writer io.Writer) (*fsm.SnapshotResponse, error)
+	IncrementalSnapshot(ctx context.Context, writer io.Writer, sinceIndex uint64) (*fsm.SnapshotResponse, error)
+}
+
+// ActiveTableSource is the shape of e.g. *storage.Engine, whose GetTable
+// returns the concrete table.ActiveTable value type.
+type ActiveTableSource interface {
+	GetTable(name string) (table.ActiveTable, error)
+	GetTables() ([]table.Table, error)
+}
+
+// tableProvider is the internal interface used by SnapshotExporter.
+// It is identical to activeTableSource except GetTable returns the SnapshotTable
+// interface, which allows tests to inject fakes without a real Dragonboat node.
+type tableProvider interface {
+	GetTable(name string) (SnapshotTable, error)
+	GetTables() ([]table.Table, error)
+}
+
+// activeTableProviderAdapter bridges activeTableSource → tableProvider by
+// taking the address of the returned table.ActiveTable (pointer receiver needed
+// for Snapshot/IncrementalSnapshot).
+type activeTableProviderAdapter struct{ inner ActiveTableSource }
+
+func (a *activeTableProviderAdapter) GetTable(name string) (SnapshotTable, error) {
+	t, err := a.inner.GetTable(name)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (a *activeTableProviderAdapter) GetTables() ([]table.Table, error) {
+	return a.inner.GetTables()
+}
+
+// ExporterConfig holds the operational parameters for a SnapshotExporter.
+type ExporterConfig struct {
+	// Bucket is the target blob store. Must not be nil.
+	Bucket objstore.Bucket
+	// NodeID uniquely identifies the node writing artefacts (written into Meta.NodeID).
+	NodeID string
+	// FullInterval is how often a full snapshot is exported for each table.
+	FullInterval time.Duration
+	// IncrInterval is how often an incremental snapshot is exported for each table.
+	IncrInterval time.Duration
+	// IncrMaxChain is the maximum number of consecutive incremental artefacts
+	// before a new full snapshot must be taken. When the chain reaches this
+	// length the incremental tick is a no-op.
+	IncrMaxChain int
+}
+
+// SnapshotExporter periodically exports table snapshots to shared object storage.
+// It runs two background loops: one for full exports and one for incremental exports.
+type SnapshotExporter struct {
+	cfg    ExporterConfig
+	tables tableProvider
+	log    *zap.SugaredLogger
+}
+
+// NewSnapshotExporter creates a new SnapshotExporter. The caller must call Run to
+// start the background loops.
+func NewSnapshotExporter(tables ActiveTableSource, cfg ExporterConfig, log *zap.SugaredLogger) *SnapshotExporter {
+	if cfg.IncrMaxChain <= 0 {
+		cfg.IncrMaxChain = 8
+	}
+	return &SnapshotExporter{
+		cfg:    cfg,
+		tables: &activeTableProviderAdapter{inner: tables},
+		log:    log.Named("snapshot-exporter"),
+	}
+}
+
+// Run starts the exporter loops and blocks until ctx is cancelled. It is safe to
+// call Run in its own goroutine.
+func (e *SnapshotExporter) Run(ctx context.Context) {
+	fullTicker := time.NewTicker(e.cfg.FullInterval)
+	incrTicker := time.NewTicker(e.cfg.IncrInterval)
+	defer fullTicker.Stop()
+	defer incrTicker.Stop()
+
+	e.log.Info("snapshot exporter started")
+	defer e.log.Info("snapshot exporter stopped")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-fullTicker.C:
+			e.runFullExport(ctx)
+		case <-incrTicker.C:
+			e.runIncrementalExport(ctx)
+		}
+	}
+}
+
+// runFullExport exports a full snapshot for every known table.
+func (e *SnapshotExporter) runFullExport(ctx context.Context) {
+	tables, err := e.tableNames()
+	if err != nil {
+		e.log.Errorf("full export: failed to list tables: %v", err)
+		return
+	}
+	for _, t := range tables {
+		if err := e.ExportFull(ctx, t); err != nil {
+			e.log.Errorf("full export: table %s: %v", t, err)
+		}
+	}
+}
+
+// runIncrementalExport exports an incremental snapshot for every known table
+// as long as the current incremental chain has not exceeded IncrMaxChain.
+func (e *SnapshotExporter) runIncrementalExport(ctx context.Context) {
+	tables, err := e.tableNames()
+	if err != nil {
+		e.log.Errorf("incremental export: failed to list tables: %v", err)
+		return
+	}
+	for _, t := range tables {
+		if err := e.ExportIncremental(ctx, t); err != nil {
+			e.log.Errorf("incremental export: table %s: %v", t, err)
+		}
+	}
+}
+
+// ExportFull takes a full snapshot of tableName and uploads it to the bucket.
+// It is idempotent: if a committed meta file already exists for the current
+// tip index the call is a no-op.
+func (e *SnapshotExporter) ExportFull(ctx context.Context, tableName string) error {
+	sf, err := snapshot.NewTemp()
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() {
+		_ = sf.Close()
+		_ = os.Remove(sf.Path())
+	}()
+
+	// Write snapshot in armada-command-v1 format (snappy-compressed, length-prefixed).
+	tipIndex, err := e.snapshot(ctx, tableName, sf)
+	if err != nil {
+		return fmt.Errorf("snapshot: %w", err)
+	}
+
+	// Append DUMMY command carrying the leader index — required so followers
+	// can advance sysLeaderIndex even when the delta was empty.
+	final, err := (&armadapb.Command{
+		Table:       []byte(tableName),
+		Type:        armadapb.Command_DUMMY,
+		LeaderIndex: &tipIndex,
+	}).MarshalVT()
+	if err != nil {
+		return fmt.Errorf("marshal dummy command: %w", err)
+	}
+	if _, err := sf.Write(final); err != nil {
+		return fmt.Errorf("write dummy command: %w", err)
+	}
+	if err := sf.Sync(); err != nil {
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+
+	fi, err := sf.File.Stat()
+	if err != nil {
+		return fmt.Errorf("stat temp file: %w", err)
+	}
+	size := fi.Size()
+
+	metaKey := FullMetaKey(tableName, tipIndex)
+
+	// Idempotency: skip if already committed.
+	if exists, _ := e.cfg.Bucket.Exists(ctx, metaKey); exists {
+		e.log.Debugf("full snapshot for table %s at index %d already committed, skipping", tableName, tipIndex)
+		return nil
+	}
+
+	// Compute SHA-256 of the raw compressed file bytes.
+	checksum, err := fileSHA256(sf.File)
+	if err != nil {
+		return fmt.Errorf("sha256: %w", err)
+	}
+
+	// Upload the snapshot data.
+	snapKey := FullSnapKey(tableName, tipIndex)
+	if _, err := sf.File.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if err := e.cfg.Bucket.Upload(ctx, snapKey, sf.File); err != nil {
+		if cleanErr := e.cfg.Bucket.Delete(ctx, snapKey); cleanErr != nil && !e.cfg.Bucket.IsObjNotFoundErr(cleanErr) {
+			e.log.Warnf("upload failed and cleanup of partial artefact %s also failed: %v", snapKey, cleanErr)
+		}
+		return fmt.Errorf("upload snapshot: %w", err)
+	}
+
+	// Commit: write the meta file.
+	meta := Meta{
+		Table:     tableName,
+		Type:      SnapshotTypeFull,
+		BaseIndex: 0,
+		TipIndex:  tipIndex,
+		SizeBytes: size,
+		SHA256:    checksum,
+		CreatedAt: time.Now().UTC(),
+		NodeID:    e.cfg.NodeID,
+		Format:    SnapshotFormat,
+	}
+	if err := e.uploadMeta(ctx, metaKey, meta); err != nil {
+		return err
+	}
+	e.log.Infof("exported full snapshot for table %s at index %d (%d bytes)", tableName, tipIndex, size)
+	return nil
+}
+
+// ExportIncremental takes an incremental snapshot of tableName (delta since the
+// latest committed artefact) and uploads it to the bucket. If no full snapshot
+// exists yet, or the incremental chain length has reached IncrMaxChain, the
+// call is a no-op and callers should wait for the next full export.
+func (e *SnapshotExporter) ExportIncremental(ctx context.Context, tableName string) error {
+	baseIndex, chainLen, err := e.findChainTip(ctx, tableName)
+	if err != nil {
+		return fmt.Errorf("find chain tip: %w", err)
+	}
+	if baseIndex == 0 {
+		// No full snapshot yet — incremental is not possible.
+		e.log.Debugf("incremental export: no full snapshot for table %s, skipping", tableName)
+		return nil
+	}
+	if chainLen >= e.cfg.IncrMaxChain {
+		e.log.Debugf("incremental export: chain length %d >= max %d for table %s, waiting for full", chainLen, e.cfg.IncrMaxChain, tableName)
+		return nil
+	}
+
+	sf, err := snapshot.NewTemp()
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() {
+		_ = sf.Close()
+		_ = os.Remove(sf.Path())
+	}()
+
+	tipIndex, err := e.incrementalSnapshot(ctx, tableName, sf, baseIndex)
+	if err != nil {
+		return fmt.Errorf("incremental snapshot: %w", err)
+	}
+
+	if tipIndex == baseIndex {
+		// Nothing new to export.
+		e.log.Debugf("incremental export: no new data for table %s since index %d", tableName, baseIndex)
+		return nil
+	}
+
+	// Append DUMMY command.
+	final, err := (&armadapb.Command{
+		Table:       []byte(tableName),
+		Type:        armadapb.Command_DUMMY,
+		LeaderIndex: &tipIndex,
+	}).MarshalVT()
+	if err != nil {
+		return fmt.Errorf("marshal dummy command: %w", err)
+	}
+	if _, err := sf.Write(final); err != nil {
+		return fmt.Errorf("write dummy command: %w", err)
+	}
+	if err := sf.Sync(); err != nil {
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+
+	fi, err := sf.File.Stat()
+	if err != nil {
+		return fmt.Errorf("stat temp file: %w", err)
+	}
+	size := fi.Size()
+
+	metaKey := IncrMetaKey(tableName, baseIndex, tipIndex)
+	if exists, _ := e.cfg.Bucket.Exists(ctx, metaKey); exists {
+		e.log.Debugf("incremental snapshot for table %s (%d→%d) already committed, skipping", tableName, baseIndex, tipIndex)
+		return nil
+	}
+
+	checksum, err := fileSHA256(sf.File)
+	if err != nil {
+		return fmt.Errorf("sha256: %w", err)
+	}
+
+	snapKey := IncrSnapKey(tableName, baseIndex, tipIndex)
+	if _, err := sf.File.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if err := e.cfg.Bucket.Upload(ctx, snapKey, sf.File); err != nil {
+		if cleanErr := e.cfg.Bucket.Delete(ctx, snapKey); cleanErr != nil && !e.cfg.Bucket.IsObjNotFoundErr(cleanErr) {
+			e.log.Warnf("upload failed and cleanup of partial artefact %s also failed: %v", snapKey, cleanErr)
+		}
+		return fmt.Errorf("upload snapshot: %w", err)
+	}
+
+	meta := Meta{
+		Table:     tableName,
+		Type:      SnapshotTypeIncremental,
+		BaseIndex: baseIndex,
+		TipIndex:  tipIndex,
+		SizeBytes: size,
+		SHA256:    checksum,
+		CreatedAt: time.Now().UTC(),
+		NodeID:    e.cfg.NodeID,
+		Format:    SnapshotFormat,
+	}
+	if err := e.uploadMeta(ctx, metaKey, meta); err != nil {
+		return err
+	}
+	e.log.Infof("exported incremental snapshot for table %s (%d→%d, chain %d/%d, %d bytes)",
+		tableName, baseIndex, tipIndex, chainLen+1, e.cfg.IncrMaxChain, size)
+	return nil
+}
+
+// findChainTip discovers the latest committed artefact for tableName and
+// returns the tip index and the current incremental chain length.
+// baseIndex == 0 means no full snapshot exists yet.
+func (e *SnapshotExporter) findChainTip(ctx context.Context, tableName string) (baseIndex uint64, chainLen int, err error) {
+	prefix := fmt.Sprintf("snapshots/%s/", tableName)
+
+	var fullMeta *Meta
+	var incrMetas []Meta
+
+	iterErr := e.cfg.Bucket.Iter(ctx, prefix, func(name string) error {
+		if !strings.HasSuffix(name, ".meta") {
+			return nil
+		}
+		r, err := e.cfg.Bucket.Get(ctx, name)
+		if err != nil {
+			if e.cfg.Bucket.IsObjNotFoundErr(err) {
+				return nil
+			}
+			return err
+		}
+		defer r.Close()
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		var m Meta
+		if err := unmarshalMeta(data, &m); err != nil {
+			return nil // skip malformed meta
+		}
+		switch m.Type {
+		case SnapshotTypeFull:
+			if fullMeta == nil || m.TipIndex > fullMeta.TipIndex {
+				cp := m
+				fullMeta = &cp
+			}
+		case SnapshotTypeIncremental:
+			incrMetas = append(incrMetas, m)
+		}
+		return nil
+	}, objstore.WithRecursiveIter())
+	if iterErr != nil {
+		return 0, 0, iterErr
+	}
+	if fullMeta == nil {
+		return 0, 0, nil
+	}
+
+	// Walk the incremental chain forward from the latest full tip.
+	chainTip := fullMeta.TipIndex
+	for {
+		var next *Meta
+		for i := range incrMetas {
+			if incrMetas[i].BaseIndex == chainTip {
+				next = &incrMetas[i]
+				break
+			}
+		}
+		if next == nil {
+			break
+		}
+		chainTip = next.TipIndex
+		chainLen++
+	}
+
+	return chainTip, chainLen, nil
+}
+
+// ListMeta lists all committed Meta artefacts for tableName, sorted by TipIndex ascending.
+func (e *SnapshotExporter) ListMeta(ctx context.Context, tableName string) ([]Meta, error) {
+	prefix := fmt.Sprintf("snapshots/%s/", tableName)
+	var metas []Meta
+	err := e.cfg.Bucket.Iter(ctx, prefix, func(name string) error {
+		if !strings.HasSuffix(name, ".meta") {
+			return nil
+		}
+		r, err := e.cfg.Bucket.Get(ctx, name)
+		if err != nil {
+			if e.cfg.Bucket.IsObjNotFoundErr(err) {
+				return nil
+			}
+			return err
+		}
+		defer r.Close()
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		var m Meta
+		if err := unmarshalMeta(data, &m); err != nil {
+			return nil
+		}
+		metas = append(metas, m)
+		return nil
+	}, objstore.WithRecursiveIter())
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].TipIndex < metas[j].TipIndex
+	})
+	return metas, nil
+}
+
+// uploadMeta marshals m and uploads it to key.
+func (e *SnapshotExporter) uploadMeta(ctx context.Context, key string, m Meta) error {
+	data, err := marshalMeta(m)
+	if err != nil {
+		return fmt.Errorf("marshal meta: %w", err)
+	}
+	if err := e.cfg.Bucket.Upload(ctx, key, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("upload meta %s: %w", key, err)
+	}
+	return nil
+}
+
+// fileSHA256 computes the hex-encoded SHA-256 of the raw file content,
+// seeking to the start before reading and restoring the position afterwards.
+func fileSHA256(f *os.File) (string, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (e *SnapshotExporter) tableNames() ([]string, error) {
+	tables, err := e.tables.GetTables()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(tables))
+	for i, t := range tables {
+		names[i] = t.Name
+	}
+	return names, nil
+}
+
+func (e *SnapshotExporter) snapshot(ctx context.Context, tableName string, w io.Writer) (uint64, error) {
+	t, err := e.tables.GetTable(tableName)
+	if err != nil {
+		return 0, fmt.Errorf("get table %s: %w", tableName, err)
+	}
+	resp, err := t.Snapshot(ctx, w)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Index, nil
+}
+
+func (e *SnapshotExporter) incrementalSnapshot(ctx context.Context, tableName string, w io.Writer, sinceIndex uint64) (uint64, error) {
+	t, err := e.tables.GetTable(tableName)
+	if err != nil {
+		return 0, fmt.Errorf("get table %s: %w", tableName, err)
+	}
+	resp, err := t.IncrementalSnapshot(ctx, w, sinceIndex)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Index, nil
+}

--- a/replication/store/exporter.go
+++ b/replication/store/exporter.go
@@ -187,7 +187,7 @@ func (e *SnapshotExporter) ExportFull(ctx context.Context, tableName string) err
 		return fmt.Errorf("sync temp file: %w", err)
 	}
 
-	fi, err := sf.File.Stat()
+	fi, err := sf.Stat()
 	if err != nil {
 		return fmt.Errorf("stat temp file: %w", err)
 	}
@@ -209,7 +209,7 @@ func (e *SnapshotExporter) ExportFull(ctx context.Context, tableName string) err
 
 	// Upload the snapshot data.
 	snapKey := FullSnapKey(tableName, tipIndex)
-	if _, err := sf.File.Seek(0, io.SeekStart); err != nil {
+	if _, err := sf.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 	if err := e.cfg.Bucket.Upload(ctx, snapKey, sf.File); err != nil {
@@ -293,7 +293,7 @@ func (e *SnapshotExporter) ExportIncremental(ctx context.Context, tableName stri
 		return fmt.Errorf("sync temp file: %w", err)
 	}
 
-	fi, err := sf.File.Stat()
+	fi, err := sf.Stat()
 	if err != nil {
 		return fmt.Errorf("stat temp file: %w", err)
 	}
@@ -311,7 +311,7 @@ func (e *SnapshotExporter) ExportIncremental(ctx context.Context, tableName stri
 	}
 
 	snapKey := IncrSnapKey(tableName, baseIndex, tipIndex)
-	if _, err := sf.File.Seek(0, io.SeekStart); err != nil {
+	if _, err := sf.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 	if err := e.cfg.Bucket.Upload(ctx, snapKey, sf.File); err != nil {

--- a/replication/store/exporter_test.go
+++ b/replication/store/exporter_test.go
@@ -1,0 +1,555 @@
+// Copyright JAMF Software, LLC
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/armadakv/armada/armadapb"
+	"github.com/armadakv/armada/replication/snapshot"
+	"github.com/armadakv/armada/storage/table"
+	"github.com/armadakv/armada/storage/table/fsm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"go.uber.org/zap"
+)
+
+// fakeTableService implements tableProvider for use in tests.
+type fakeTableService struct {
+	tableNames []string
+	// index returned by Snapshot (simulates the applied leader index)
+	snapshotIdx uint64
+	// index returned by IncrementalSnapshot
+	incrIdx uint64
+	// data to write during Snapshot / IncrementalSnapshot
+	snapshotData []byte
+}
+
+func (f *fakeTableService) GetTables() ([]table.Table, error) {
+	tables := make([]table.Table, len(f.tableNames))
+	for i, name := range f.tableNames {
+		tables[i] = table.Table{Name: name}
+	}
+	return tables, nil
+}
+
+func (f *fakeTableService) GetTable(name string) (SnapshotTable, error) {
+	for _, n := range f.tableNames {
+		if n == name {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("table %q not found", name)
+}
+
+func (f *fakeTableService) Snapshot(_ context.Context, w io.Writer) (*fsm.SnapshotResponse, error) {
+	if len(f.snapshotData) > 0 {
+		if _, err := w.Write(f.snapshotData); err != nil {
+			return nil, err
+		}
+	}
+	return &fsm.SnapshotResponse{Index: f.snapshotIdx}, nil
+}
+
+func (f *fakeTableService) IncrementalSnapshot(_ context.Context, w io.Writer, _ uint64) (*fsm.SnapshotResponse, error) {
+	if len(f.snapshotData) > 0 {
+		if _, err := w.Write(f.snapshotData); err != nil {
+			return nil, err
+		}
+	}
+	return &fsm.SnapshotResponse{Index: f.incrIdx}, nil
+}
+
+// makeSnapshotData returns a minimal armadapb.Command serialized via the
+// replication/snapshot snappy+length-prefix format so the exporter temp file
+// is non-empty and well-formed.
+func makeSnapshotData(t *testing.T) []byte {
+	t.Helper()
+	// The snapshot writer expects raw proto bytes (not yet length-prefixed).
+	// We simulate what table.Snapshot() produces: raw marshaled Commands.
+	cmd := &armadapb.Command{
+		Table: []byte("test"),
+		Type:  armadapb.Command_PUT,
+		Kv:    &armadapb.KeyValue{Key: []byte("k"), Value: []byte("v")},
+	}
+	b, err := cmd.MarshalVT()
+	require.NoError(t, err)
+	return b
+}
+
+func newTestLogger() *zap.SugaredLogger {
+	l, _ := zap.NewDevelopment()
+	return l.Sugar()
+}
+
+// TestExportFull_Basic verifies that ExportFull uploads a .snap and .meta file.
+func TestExportFull_Basic(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"orders"},
+		snapshotIdx:  42,
+		snapshotData: makeSnapshotData(t),
+	}
+
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "leader-1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+
+	ctx := context.Background()
+	require.NoError(t, exp.ExportFull(ctx, "orders"))
+
+	snapKey := FullSnapKey("orders", 42)
+	metaKey := FullMetaKey("orders", 42)
+
+	// Both artefact and meta must exist.
+	ok, err := bucket.Exists(ctx, snapKey)
+	require.NoError(t, err)
+	assert.True(t, ok, "snap key should exist")
+
+	ok, err = bucket.Exists(ctx, metaKey)
+	require.NoError(t, err)
+	assert.True(t, ok, "meta key should exist")
+
+	// Parse and validate the meta.
+	r, err := bucket.Get(ctx, metaKey)
+	require.NoError(t, err)
+	defer r.Close()
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	var m Meta
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Equal(t, "orders", m.Table)
+	assert.Equal(t, SnapshotTypeFull, m.Type)
+	assert.Equal(t, uint64(0), m.BaseIndex)
+	assert.Equal(t, uint64(42), m.TipIndex)
+	assert.Equal(t, "leader-1", m.NodeID)
+	assert.Equal(t, SnapshotFormat, m.Format)
+	assert.NotEmpty(t, m.SHA256)
+	assert.Greater(t, m.SizeBytes, int64(0))
+}
+
+// TestExportFull_Idempotent verifies that calling ExportFull twice with the same
+// tip index does not overwrite the artefact and returns no error.
+func TestExportFull_Idempotent(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"orders"},
+		snapshotIdx:  100,
+		snapshotData: makeSnapshotData(t),
+	}
+
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "leader-1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+
+	ctx := context.Background()
+	require.NoError(t, exp.ExportFull(ctx, "orders"))
+
+	// Count objects before second call.
+	before := len(bucket.Objects())
+	require.NoError(t, exp.ExportFull(ctx, "orders"))
+	after := len(bucket.Objects())
+
+	assert.Equal(t, before, after, "second ExportFull should not add new objects")
+}
+
+// TestExportFull_MultipleTablesAddsAllMeta verifies full export writes meta
+// for multiple tables.
+func TestExportFull_MultipleTablesAddsAllMeta(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"t1", "t2", "t3"},
+		snapshotIdx:  10,
+		snapshotData: makeSnapshotData(t),
+	}
+
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+
+	ctx := context.Background()
+	for _, tbl := range []string{"t1", "t2", "t3"} {
+		require.NoError(t, exp.ExportFull(ctx, tbl))
+	}
+
+	for _, tbl := range []string{"t1", "t2", "t3"} {
+		ok, err := bucket.Exists(ctx, FullMetaKey(tbl, 10))
+		require.NoError(t, err)
+		assert.True(t, ok, "meta for %s should exist", tbl)
+	}
+}
+
+// TestExportIncremental_RequiresFullFirst verifies that ExportIncremental is a
+// no-op when no full snapshot exists.
+func TestExportIncremental_RequiresFullFirst(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{tableNames: []string{"orders"}, incrIdx: 50}
+
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+
+	ctx := context.Background()
+	require.NoError(t, exp.ExportIncremental(ctx, "orders"))
+
+	// Bucket should remain empty.
+	assert.Equal(t, 0, len(bucket.Objects()))
+}
+
+// TestExportIncremental_AfterFull verifies that ExportIncremental produces an
+// incremental artefact once a full snapshot exists.
+func TestExportIncremental_AfterFull(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"orders"},
+		snapshotIdx:  100,
+		incrIdx:      200,
+		snapshotData: makeSnapshotData(t),
+	}
+
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+
+	ctx := context.Background()
+	// First, create a full
+	require.NoError(t, exp.ExportFull(ctx, "orders"))
+	// Now take an incremental.
+	require.NoError(t, exp.ExportIncremental(ctx, "orders"))
+
+	incrSnapKey := IncrSnapKey("orders", 100, 200)
+	incrMetaKey := IncrMetaKey("orders", 100, 200)
+
+	ok, err := bucket.Exists(ctx, incrSnapKey)
+	require.NoError(t, err)
+	assert.True(t, ok, "incremental snap should exist")
+
+	ok, err = bucket.Exists(ctx, incrMetaKey)
+	require.NoError(t, err)
+	assert.True(t, ok, "incremental meta should exist")
+
+	r, err := bucket.Get(ctx, incrMetaKey)
+	require.NoError(t, err)
+	defer r.Close()
+	data, _ := io.ReadAll(r)
+
+	var m Meta
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, SnapshotTypeIncremental, m.Type)
+	assert.Equal(t, uint64(100), m.BaseIndex)
+	assert.Equal(t, uint64(200), m.TipIndex)
+}
+
+// TestExportIncremental_ChainLimitSkips verifies that incremental export is a
+// no-op once the chain length reaches IncrMaxChain.
+func TestExportIncremental_ChainLimitSkips(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	maxChain := 3
+
+	// We'll manually insert meta objects simulating a chain of length maxChain.
+	ctx := context.Background()
+	writeMeta := func(m Meta, key string) {
+		data, _ := json.Marshal(m)
+		require.NoError(t, bucket.Upload(ctx, key, bytes.NewReader(data)))
+	}
+
+	// Insert full meta at tip=100.
+	writeMeta(Meta{
+		Table: "t", Type: SnapshotTypeFull, TipIndex: 100, Format: SnapshotFormat,
+	}, FullMetaKey("t", 100))
+
+	// Insert incremental chain: 100→110, 110→120, 120→130.
+	writeMeta(Meta{Table: "t", Type: SnapshotTypeIncremental, BaseIndex: 100, TipIndex: 110}, IncrMetaKey("t", 100, 110))
+	writeMeta(Meta{Table: "t", Type: SnapshotTypeIncremental, BaseIndex: 110, TipIndex: 120}, IncrMetaKey("t", 110, 120))
+	writeMeta(Meta{Table: "t", Type: SnapshotTypeIncremental, BaseIndex: 120, TipIndex: 130}, IncrMetaKey("t", 120, 130))
+
+	svc := &fakeTableService{tableNames: []string{"t"}, snapshotIdx: 100, incrIdx: 140, snapshotData: makeSnapshotData(t)}
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: maxChain,
+	}, log: newTestLogger()}
+
+	before := len(bucket.Objects())
+	require.NoError(t, exp.ExportIncremental(ctx, "t"))
+	after := len(bucket.Objects())
+
+	assert.Equal(t, before, after, "ExportIncremental should be a no-op when chain is at max length")
+}
+
+// TestExportIncremental_NoNewData verifies ExportIncremental is a no-op when
+// tip equals base (nothing changed).
+func TestExportIncremental_NoNewData(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	ctx := context.Background()
+
+	// Pre-seed a full snapshot meta at index 50.
+	data, _ := json.Marshal(Meta{
+		Table: "orders", Type: SnapshotTypeFull, TipIndex: 50, Format: SnapshotFormat,
+	})
+	require.NoError(t, bucket.Upload(ctx, FullMetaKey("orders", 50), bytes.NewReader(data)))
+
+	svc := &fakeTableService{
+		tableNames:  []string{"orders"},
+		snapshotIdx: 50,
+		incrIdx:     50, // same as base → no new data
+	}
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 8,
+	}, log: newTestLogger()}
+
+	before := len(bucket.Objects())
+	require.NoError(t, exp.ExportIncremental(ctx, "orders"))
+	after := len(bucket.Objects())
+
+	assert.Equal(t, before, after, "no-op when tip == base")
+}
+
+// TestListMeta verifies ListMeta returns all committed artefacts in order.
+func TestListMeta(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	ctx := context.Background()
+
+	uploadMeta := func(m Meta, key string) {
+		data, _ := json.Marshal(m)
+		require.NoError(t, bucket.Upload(ctx, key, bytes.NewReader(data)))
+	}
+	uploadMeta(Meta{Table: "t", Type: SnapshotTypeFull, TipIndex: 10}, FullMetaKey("t", 10))
+	uploadMeta(Meta{Table: "t", Type: SnapshotTypeIncremental, BaseIndex: 10, TipIndex: 20}, IncrMetaKey("t", 10, 20))
+	uploadMeta(Meta{Table: "t", Type: SnapshotTypeIncremental, BaseIndex: 20, TipIndex: 30}, IncrMetaKey("t", 20, 30))
+
+	svc := &fakeTableService{tableNames: []string{"t"}}
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n1",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 8,
+	}, log: newTestLogger()}
+
+	metas, err := exp.ListMeta(ctx, "t")
+	require.NoError(t, err)
+	require.Len(t, metas, 3)
+	assert.Equal(t, uint64(10), metas[0].TipIndex)
+	assert.Equal(t, uint64(20), metas[1].TipIndex)
+	assert.Equal(t, uint64(30), metas[2].TipIndex)
+}
+
+// TestObjectKeyScheme validates all key helpers produce expected paths.
+func TestObjectKeyScheme(t *testing.T) {
+	assert.Equal(t, "snapshots/orders/full/100.snap", FullSnapKey("orders", 100))
+	assert.Equal(t, "snapshots/orders/full/100.snap.meta", FullMetaKey("orders", 100))
+	assert.Equal(t, "snapshots/orders/incr/100_200.snap", IncrSnapKey("orders", 100, 200))
+	assert.Equal(t, "snapshots/orders/incr/100_200.snap.meta", IncrMetaKey("orders", 100, 200))
+	assert.Equal(t, "snapshots/orders/.lease/node1", LeaseKey("orders", "node1"))
+	assert.True(t, strings.HasPrefix(GCLogKey(time.Now()), "gc/"))
+}
+
+// Integration test: use a real filesystem bucket and simulate the full
+// export + incremental chain + GC lifecycle.
+func TestExporterGCIntegration(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"users"},
+		snapshotIdx:  1000,
+		incrIdx:      1100,
+		snapshotData: makeSnapshotData(t),
+	}
+	cfg := ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "integration-node",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}
+	exp := &SnapshotExporter{tables: svc, cfg: cfg, log: newTestLogger()}
+
+	// --- Phase 1: Export full snapshot ---
+	require.NoError(t, exp.ExportFull(ctx, "users"))
+	metas, err := exp.ListMeta(ctx, "users")
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, SnapshotTypeFull, metas[0].Type)
+	assert.Equal(t, uint64(1000), metas[0].TipIndex)
+
+	// --- Phase 2: Export incremental ---
+	require.NoError(t, exp.ExportIncremental(ctx, "users"))
+	metas, err = exp.ListMeta(ctx, "users")
+	require.NoError(t, err)
+	require.Len(t, metas, 2)
+	assert.Equal(t, SnapshotTypeIncremental, metas[1].Type)
+	assert.Equal(t, uint64(1000), metas[1].BaseIndex)
+	assert.Equal(t, uint64(1100), metas[1].TipIndex)
+
+	// --- Phase 3: GC with long retention (nothing deleted) ---
+	gcCfg := GCConfig{
+		Bucket:    bucket,
+		Retention: 48 * time.Hour,
+		Interval:  time.Hour,
+	}
+	gcWorker := NewGCWorker(gcCfg, newTestLogger())
+	require.NoError(t, gcWorker.RunOnce(ctx))
+
+	metas, err = exp.ListMeta(ctx, "users")
+	require.NoError(t, err)
+	assert.Len(t, metas, 2, "GC should not delete recent artefacts")
+
+	// --- Phase 4: Export a new full snapshot (simulating the next full cycle) ---
+	svc.snapshotIdx = 2000
+	require.NoError(t, exp.ExportFull(ctx, "users"))
+	metas, err = exp.ListMeta(ctx, "users")
+	require.NoError(t, err)
+	assert.Len(t, metas, 3, "two fulls + one incr")
+
+	// --- Phase 5: GC with zero retention → old full + old incr deleted ---
+	gcCfg.Retention = 0
+	gcWorker = NewGCWorker(gcCfg, newTestLogger())
+	require.NoError(t, gcWorker.RunOnce(ctx))
+
+	metas, err = exp.ListMeta(ctx, "users")
+	require.NoError(t, err)
+	// Only the newest full should survive (the incr at base=1000 is before the new
+	// latest-full tip=2000 and should be deleted).
+	assert.Len(t, metas, 1)
+	assert.Equal(t, SnapshotTypeFull, metas[0].Type)
+	assert.Equal(t, uint64(2000), metas[0].TipIndex)
+}
+
+// TestExporter_SHA256IsConsistent verifies that successive calls with the same
+// data produce the same SHA256 in the meta.
+func TestExporter_SHA256IsConsistent(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	svc := &fakeTableService{
+		tableNames:   []string{"t"},
+		snapshotIdx:  1,
+		snapshotData: makeSnapshotData(t),
+	}
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+	require.NoError(t, exp.ExportFull(ctx, "t"))
+
+	r, err := bucket.Get(ctx, FullMetaKey("t", 1))
+	require.NoError(t, err)
+	defer r.Close()
+	data, _ := io.ReadAll(r)
+	var m Meta
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Len(t, m.SHA256, 64, "SHA256 should be 64 hex characters")
+}
+
+// TestSnapshotFileFormat_WrittenToReader verifies that an ExportFull artefact
+// can be round-tripped through the replication/snapshot reader.
+func TestSnapshotFileFormat_WrittenToReader(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	// Write a real command via the snapshotFile format.
+	cmd := &armadapb.Command{
+		Table: []byte("test"),
+		Type:  armadapb.Command_PUT,
+		Kv:    &armadapb.KeyValue{Key: []byte("hello"), Value: []byte("world")},
+	}
+	cmdBytes, err := cmd.MarshalVT()
+	require.NoError(t, err)
+
+	svc := &fakeTableService{
+		tableNames:   []string{"test"},
+		snapshotIdx:  7,
+		snapshotData: cmdBytes,
+	}
+	exp := &SnapshotExporter{tables: svc, cfg: ExporterConfig{
+		Bucket:       bucket,
+		NodeID:       "n",
+		FullInterval: time.Hour,
+		IncrInterval: 30 * time.Minute,
+		IncrMaxChain: 4,
+	}, log: newTestLogger()}
+	require.NoError(t, exp.ExportFull(ctx, "test"))
+
+	// Download the snap and verify we can read back the commands.
+	r, err := bucket.Get(ctx, FullSnapKey("test", 7))
+	require.NoError(t, err)
+	defer r.Close()
+
+	snapData, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NotEmpty(t, snapData, "snap should not be empty")
+
+	// Parse via the snapshotFile reader (snappy+length-prefix).
+	sf, err := snapshot.NewTemp()
+	require.NoError(t, err)
+	defer sf.Close()
+	_, err = sf.File.Write(snapData)
+	require.NoError(t, err)
+	_, err = sf.File.Seek(0, 0)
+	require.NoError(t, err)
+
+	// Read back commands (should include the PUT command and the trailing DUMMY).
+	var readCmds []*armadapb.Command
+	buf := make([]byte, 64*1024)
+	for {
+		n, readErr := sf.Read(buf)
+		if readErr != nil {
+			break
+		}
+		if n == 0 {
+			continue
+		}
+		var c armadapb.Command
+		if unmarshalErr := c.UnmarshalVT(buf[:n]); unmarshalErr != nil {
+			break
+		}
+		readCmds = append(readCmds, &c)
+	}
+
+	require.GreaterOrEqual(t, len(readCmds), 1, "should read at least the DUMMY command")
+	// The last command must be a DUMMY with the leader index set.
+	last := readCmds[len(readCmds)-1]
+	assert.Equal(t, armadapb.Command_DUMMY, last.Type)
+	require.NotNil(t, last.LeaderIndex)
+	assert.Equal(t, uint64(7), *last.LeaderIndex)
+}

--- a/replication/store/exporter_test.go
+++ b/replication/store/exporter_test.go
@@ -139,7 +139,7 @@ func TestExportFull_Basic(t *testing.T) {
 	assert.Equal(t, "leader-1", m.NodeID)
 	assert.Equal(t, SnapshotFormat, m.Format)
 	assert.NotEmpty(t, m.SHA256)
-	assert.Greater(t, m.SizeBytes, int64(0))
+	assert.Positive(t, m.SizeBytes)
 }
 
 // TestExportFull_Idempotent verifies that calling ExportFull twice with the same
@@ -219,7 +219,7 @@ func TestExportIncremental_RequiresFullFirst(t *testing.T) {
 	require.NoError(t, exp.ExportIncremental(ctx, "orders"))
 
 	// Bucket should remain empty.
-	assert.Equal(t, 0, len(bucket.Objects()))
+	assert.Empty(t, bucket.Objects())
 }
 
 // TestExportIncremental_AfterFull verifies that ExportIncremental produces an
@@ -525,7 +525,7 @@ func TestSnapshotFileFormat_WrittenToReader(t *testing.T) {
 	defer sf.Close()
 	_, err = sf.File.Write(snapData)
 	require.NoError(t, err)
-	_, err = sf.File.Seek(0, 0)
+	_, err = sf.Seek(0, 0)
 	require.NoError(t, err)
 
 	// Read back commands (should include the PUT command and the trailing DUMMY).

--- a/replication/store/gc.go
+++ b/replication/store/gc.go
@@ -1,0 +1,277 @@
+// Copyright JAMF Software, LLC
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/thanos-io/objstore"
+	"go.uber.org/zap"
+)
+
+// GCConfig holds the configuration for the GC worker.
+type GCConfig struct {
+	// Bucket is the blob store to garbage-collect. Must not be nil.
+	Bucket objstore.Bucket
+	// Retention is the maximum age of snapshot artefacts. Artefacts older than
+	// this duration (subject to safety exceptions) are deleted.
+	Retention time.Duration
+	// Interval controls how often the GC cycle runs.
+	Interval time.Duration
+}
+
+// GCWorker periodically deletes stale snapshot artefacts from shared object storage.
+// It preserves at least one full snapshot per table and the active incremental chain.
+type GCWorker struct {
+	cfg GCConfig
+	log *zap.SugaredLogger
+}
+
+// NewGCWorker creates a new GCWorker. The caller must call Run to start it.
+func NewGCWorker(cfg GCConfig, log *zap.SugaredLogger) *GCWorker {
+	return &GCWorker{
+		cfg: cfg,
+		log: log.Named("snapshot-gc"),
+	}
+}
+
+// Run starts the GC loop and blocks until ctx is cancelled.
+func (g *GCWorker) Run(ctx context.Context) {
+	t := time.NewTicker(g.cfg.Interval)
+	defer t.Stop()
+
+	g.log.Info("snapshot GC worker started")
+	defer g.log.Info("snapshot GC worker stopped")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := g.RunOnce(ctx); err != nil {
+				g.log.Errorf("snapshot GC error: %v", err)
+			}
+		}
+	}
+}
+
+// RunOnce performs a single GC cycle. It is exported so tests can trigger it directly.
+func (g *GCWorker) RunOnce(ctx context.Context) error {
+	tableArtefacts, err := g.collectArtefacts(ctx)
+	if err != nil {
+		return fmt.Errorf("collect artefacts: %w", err)
+	}
+
+	leased, err := g.collectLeases(ctx)
+	if err != nil {
+		return fmt.Errorf("collect leases: %w", err)
+	}
+
+	cutoff := time.Now().UTC().Add(-g.cfg.Retention)
+	var deleted int
+
+	for _, artefacts := range tableArtefacts {
+		d, err := g.gcTable(ctx, artefacts, leased, cutoff)
+		if err != nil {
+			g.log.Errorf("GC table: %v", err)
+			continue
+		}
+		deleted += d
+	}
+
+	if deleted > 0 {
+		g.log.Infof("GC cycle complete: deleted %d artefact(s)", deleted)
+	}
+	return nil
+}
+
+// tableArtefact groups a Meta with its associated object keys.
+type tableArtefact struct {
+	meta    Meta
+	snapKey string
+	metaKey string
+}
+
+// collectArtefacts walks all .meta files under snapshots/ and groups them by table name.
+func (g *GCWorker) collectArtefacts(ctx context.Context) (map[string][]tableArtefact, error) {
+	result := make(map[string][]tableArtefact)
+
+	err := g.cfg.Bucket.Iter(ctx, "snapshots/", func(name string) error {
+		if !strings.HasSuffix(name, ".meta") {
+			return nil
+		}
+		// Skip lease files.
+		if strings.Contains(name, "/.lease/") {
+			return nil
+		}
+
+		r, err := g.cfg.Bucket.Get(ctx, name)
+		if err != nil {
+			if g.cfg.Bucket.IsObjNotFoundErr(err) {
+				return nil
+			}
+			return err
+		}
+		defer r.Close()
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		var m Meta
+		if err := unmarshalMeta(data, &m); err != nil {
+			return nil // skip malformed meta files
+		}
+
+		snapKey := strings.TrimSuffix(name, ".meta")
+		result[m.Table] = append(result[m.Table], tableArtefact{
+			meta:    m,
+			snapKey: snapKey,
+			metaKey: name,
+		})
+		return nil
+	}, objstore.WithRecursiveIter())
+
+	return result, err
+}
+
+// collectLeases returns the set of object keys that have a downloader lease.
+func (g *GCWorker) collectLeases(ctx context.Context) (map[string]struct{}, error) {
+	leased := make(map[string]struct{})
+	err := g.cfg.Bucket.Iter(ctx, "snapshots/", func(name string) error {
+		if !strings.Contains(name, "/.lease/") {
+			return nil
+		}
+		// The lease key is snapshots/{table}/.lease/{node_id}; it protects
+		// the snap key without the lease suffix. We mark the table prefix as
+		// leased so any artefact for that table is preserved.
+		parts := strings.SplitN(name, "/.lease/", 2)
+		if len(parts) == 2 {
+			leased[parts[0]] = struct{}{}
+		}
+		return nil
+	}, objstore.WithRecursiveIter())
+	return leased, err
+}
+
+// gcTable applies GC rules to the artefacts of a single table and returns the
+// number of deleted artefacts.
+func (g *GCWorker) gcTable(ctx context.Context, artefacts []tableArtefact, leased map[string]struct{}, cutoff time.Time) (int, error) {
+	if len(artefacts) == 0 {
+		return 0, nil
+	}
+
+	tableName := artefacts[0].meta.Table
+	tablePrefix := fmt.Sprintf("snapshots/%s", tableName)
+	if _, ok := leased[tablePrefix]; ok {
+		// A downloader holds a lease on this table; skip GC entirely this cycle.
+		g.log.Debugf("GC: table %s has active lease, skipping", tableName)
+		return 0, nil
+	}
+
+	// Separate fulls from incrementals.
+	var fulls, incrs []tableArtefact
+	for _, a := range artefacts {
+		switch a.meta.Type {
+		case SnapshotTypeFull:
+			fulls = append(fulls, a)
+		case SnapshotTypeIncremental:
+			incrs = append(incrs, a)
+		}
+	}
+
+	// Sort fulls descending by TipIndex so fulls[0] is the most recent.
+	sort.Slice(fulls, func(i, j int) bool {
+		return fulls[i].meta.TipIndex > fulls[j].meta.TipIndex
+	})
+
+	// Determine the active full tip (the most recent full snapshot is always retained).
+	var latestFullTip uint64
+	if len(fulls) > 0 {
+		latestFullTip = fulls[0].meta.TipIndex
+	}
+
+	deleted := 0
+
+	// GC old full snapshots (keep the most recent one regardless of age).
+	for i, a := range fulls {
+		if i == 0 {
+			continue // always keep the latest full
+		}
+		if a.meta.CreatedAt.After(cutoff) {
+			continue // not yet expired
+		}
+		if err := g.deleteArtefact(ctx, a); err != nil {
+			g.log.Errorf("GC: delete full artefact %s: %v", a.snapKey, err)
+			continue
+		}
+		deleted++
+	}
+
+	// GC incremental snapshots.
+	for _, a := range incrs {
+		// Keep any incremental that is part of the active chain
+		// (i.e. its base is at or after the latest full tip).
+		if a.meta.BaseIndex >= latestFullTip {
+			continue
+		}
+		if a.meta.CreatedAt.After(cutoff) {
+			continue
+		}
+		if err := g.deleteArtefact(ctx, a); err != nil {
+			g.log.Errorf("GC: delete incr artefact %s: %v", a.snapKey, err)
+			continue
+		}
+		deleted++
+	}
+
+	return deleted, nil
+}
+
+// deleteArtefact writes a tombstone log entry and then deletes the snap and meta
+// objects from the bucket.
+func (g *GCWorker) deleteArtefact(ctx context.Context, a tableArtefact) error {
+	// Write a JSON tombstone for auditability before any deletion.
+	tombstone := struct {
+		Action    string       `json:"action"`
+		Table     string       `json:"table"`
+		Type      SnapshotType `json:"type"`
+		BaseIndex uint64       `json:"base_index"`
+		TipIndex  uint64       `json:"tip_index"`
+		Key       string       `json:"key"`
+		DeletedAt string       `json:"deleted_at"`
+	}{
+		Action:    "delete",
+		Table:     a.meta.Table,
+		Type:      a.meta.Type,
+		BaseIndex: a.meta.BaseIndex,
+		TipIndex:  a.meta.TipIndex,
+		Key:       a.snapKey,
+		DeletedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	tombstoneBytes, _ := json.Marshal(tombstone)
+	logKey := GCLogKey(time.Now())
+	if err := g.cfg.Bucket.Upload(ctx, logKey, bytes.NewReader(tombstoneBytes)); err != nil {
+		g.log.Warnf("GC: failed to write tombstone for %s: %v", a.snapKey, err)
+		// Non-fatal — proceed with deletion.
+	}
+
+	if err := g.cfg.Bucket.Delete(ctx, a.snapKey); err != nil {
+		if !g.cfg.Bucket.IsObjNotFoundErr(err) {
+			return fmt.Errorf("delete snap %s: %w", a.snapKey, err)
+		}
+	}
+	if err := g.cfg.Bucket.Delete(ctx, a.metaKey); err != nil {
+		if !g.cfg.Bucket.IsObjNotFoundErr(err) {
+			return fmt.Errorf("delete meta %s: %w", a.metaKey, err)
+		}
+	}
+	g.log.Infof("GC: deleted %s (table %s, %s, tip=%d)", a.snapKey, a.meta.Table, a.meta.Type, a.meta.TipIndex)
+	return nil
+}

--- a/replication/store/gc.go
+++ b/replication/store/gc.go
@@ -78,11 +78,7 @@ func (g *GCWorker) RunOnce(ctx context.Context) error {
 	var deleted int
 
 	for _, artefacts := range tableArtefacts {
-		d, err := g.gcTable(ctx, artefacts, leased, cutoff)
-		if err != nil {
-			g.log.Errorf("GC table: %v", err)
-			continue
-		}
+		d := g.gcTable(ctx, artefacts, leased, cutoff)
 		deleted += d
 	}
 
@@ -162,9 +158,9 @@ func (g *GCWorker) collectLeases(ctx context.Context) (map[string]struct{}, erro
 
 // gcTable applies GC rules to the artefacts of a single table and returns the
 // number of deleted artefacts.
-func (g *GCWorker) gcTable(ctx context.Context, artefacts []tableArtefact, leased map[string]struct{}, cutoff time.Time) (int, error) {
+func (g *GCWorker) gcTable(ctx context.Context, artefacts []tableArtefact, leased map[string]struct{}, cutoff time.Time) int {
 	if len(artefacts) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	tableName := artefacts[0].meta.Table
@@ -172,7 +168,7 @@ func (g *GCWorker) gcTable(ctx context.Context, artefacts []tableArtefact, lease
 	if _, ok := leased[tablePrefix]; ok {
 		// A downloader holds a lease on this table; skip GC entirely this cycle.
 		g.log.Debugf("GC: table %s has active lease, skipping", tableName)
-		return 0, nil
+		return 0
 	}
 
 	// Separate fulls from incrementals.
@@ -231,7 +227,7 @@ func (g *GCWorker) gcTable(ctx context.Context, artefacts []tableArtefact, lease
 		deleted++
 	}
 
-	return deleted, nil
+	return deleted
 }
 
 // deleteArtefact writes a tombstone log entry and then deletes the snap and meta

--- a/replication/store/gc_test.go
+++ b/replication/store/gc_test.go
@@ -31,7 +31,7 @@ func uploadTestSnap(t *testing.T, ctx context.Context, bucket *objstore.InMemBuc
 // setupFullAndIncrArtefacts inserts a full snapshot at tipFull and a chain of
 // `incrCount` incremental snapshots into bucket. It returns the tip index of the
 // last incremental (or tipFull when incrCount==0).
-func setupFullAndIncrArtefacts(t *testing.T, ctx context.Context, bucket *objstore.InMemBucket, table string, tipFull uint64, incrCount int, createdAt time.Time) uint64 {
+func setupFullAndIncrArtefacts(t *testing.T, ctx context.Context, bucket *objstore.InMemBucket, table string, tipFull uint64, incrCount int, createdAt time.Time) {
 	t.Helper()
 	uploadTestSnap(t, ctx, bucket, FullSnapKey(table, tipFull))
 	uploadTestMeta(t, ctx, bucket, Meta{
@@ -56,7 +56,6 @@ func setupFullAndIncrArtefacts(t *testing.T, ctx context.Context, bucket *objsto
 		}, IncrMetaKey(table, prev, next))
 		prev = next
 	}
-	return prev
 }
 
 // TestGC_NoArtefacts verifies GC handles an empty bucket without errors.

--- a/replication/store/gc_test.go
+++ b/replication/store/gc_test.go
@@ -1,0 +1,299 @@
+// Copyright JAMF Software, LLC
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+// uploadTestMeta is a helper that uploads a Meta object to the bucket.
+func uploadTestMeta(t *testing.T, ctx context.Context, bucket *objstore.InMemBucket, m Meta, key string) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(ctx, key, bytes.NewReader(data)))
+}
+
+// uploadTestSnap uploads a placeholder snap artefact.
+func uploadTestSnap(t *testing.T, ctx context.Context, bucket *objstore.InMemBucket, key string) {
+	t.Helper()
+	require.NoError(t, bucket.Upload(ctx, key, bytes.NewReader([]byte("snap-data"))))
+}
+
+// setupFullAndIncrArtefacts inserts a full snapshot at tipFull and a chain of
+// `incrCount` incremental snapshots into bucket. It returns the tip index of the
+// last incremental (or tipFull when incrCount==0).
+func setupFullAndIncrArtefacts(t *testing.T, ctx context.Context, bucket *objstore.InMemBucket, table string, tipFull uint64, incrCount int, createdAt time.Time) uint64 {
+	t.Helper()
+	uploadTestSnap(t, ctx, bucket, FullSnapKey(table, tipFull))
+	uploadTestMeta(t, ctx, bucket, Meta{
+		Table:     table,
+		Type:      SnapshotTypeFull,
+		TipIndex:  tipFull,
+		CreatedAt: createdAt,
+		Format:    SnapshotFormat,
+	}, FullMetaKey(table, tipFull))
+
+	prev := tipFull
+	for i := 0; i < incrCount; i++ {
+		next := prev + 10
+		uploadTestSnap(t, ctx, bucket, IncrSnapKey(table, prev, next))
+		uploadTestMeta(t, ctx, bucket, Meta{
+			Table:     table,
+			Type:      SnapshotTypeIncremental,
+			BaseIndex: prev,
+			TipIndex:  next,
+			CreatedAt: createdAt,
+			Format:    SnapshotFormat,
+		}, IncrMetaKey(table, prev, next))
+		prev = next
+	}
+	return prev
+}
+
+// TestGC_NoArtefacts verifies GC handles an empty bucket without errors.
+func TestGC_NoArtefacts(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour,
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(context.Background()))
+}
+
+// TestGC_RetentionPreservesRecentArtefacts verifies that artefacts newer than
+// the retention window are not deleted.
+func TestGC_RetentionPreservesRecentArtefacts(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	now := time.Now().UTC()
+
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 100, 2, now)
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: 24 * time.Hour, // objects are fresh
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// Nothing should be deleted.
+	assert.Len(t, bucket.Objects(), 6, "all artefacts should survive (snap+meta x 3)")
+}
+
+// TestGC_DeletesOldIncrementalButKeepsLatestFull verifies that old incremental
+// artefacts are removed while the latest full snapshot is always retained.
+// To qualify for deletion an incremental's base_index must be below the latest
+// full tip so it is not part of the active chain.
+func TestGC_DeletesOldIncrementalButKeepsLatestFull(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	old := time.Now().UTC().Add(-48 * time.Hour)
+
+	// Insert an old full at 100 + 2 old incrementals (100→110, 110→120).
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 100, 2, old)
+
+	// Insert a newer full at 200 — this makes the incrementals (base < 200) stale.
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 200, 0, old)
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour, // retention = 1h, objects are 48h old
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// The newest full snapshot (at 200) must survive.
+	ok, err := bucket.Exists(ctx, FullSnapKey("t", 200))
+	require.NoError(t, err)
+	assert.True(t, ok, "latest full snap should survive")
+
+	ok, err = bucket.Exists(ctx, FullMetaKey("t", 200))
+	require.NoError(t, err)
+	assert.True(t, ok, "latest full meta should survive")
+
+	// Old full at 100 should be gone.
+	ok, err = bucket.Exists(ctx, FullSnapKey("t", 100))
+	require.NoError(t, err)
+	assert.False(t, ok, "old full at 100 should be deleted")
+
+	// Old incrementals (base < 200) should be gone.
+	ok, err = bucket.Exists(ctx, IncrSnapKey("t", 100, 110))
+	require.NoError(t, err)
+	assert.False(t, ok, "old incr snap should be deleted")
+
+	ok, err = bucket.Exists(ctx, IncrMetaKey("t", 100, 110))
+	require.NoError(t, err)
+	assert.False(t, ok, "old incr meta should be deleted")
+}
+
+// TestGC_KeepsActiveIncrementalChain verifies that active incremental artefacts
+// (those chaining from the latest full) are not deleted even if they are old.
+func TestGC_KeepsActiveIncrementalChain(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	recent := time.Now().UTC()
+
+	// Old full at 100.
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 100, 0, old)
+
+	// New full at 200 (the "latest full").
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 200, 0, recent)
+
+	// Active incremental chain from the new full (200→210).
+	uploadTestSnap(t, ctx, bucket, IncrSnapKey("t", 200, 210))
+	uploadTestMeta(t, ctx, bucket, Meta{
+		Table: "t", Type: SnapshotTypeIncremental,
+		BaseIndex: 200, TipIndex: 210, CreatedAt: old, // old but part of active chain
+	}, IncrMetaKey("t", 200, 210))
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour, // old (< retention cutoff)
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// Old full at 100 should be gone (it's not the latest full).
+	ok, err := bucket.Exists(ctx, FullSnapKey("t", 100))
+	require.NoError(t, err)
+	assert.False(t, ok, "old full at 100 should be deleted")
+
+	// Latest full at 200 must survive.
+	ok, err = bucket.Exists(ctx, FullSnapKey("t", 200))
+	require.NoError(t, err)
+	assert.True(t, ok, "latest full at 200 must survive")
+
+	// Active incr chain (200→210) must survive even though it is old.
+	ok, err = bucket.Exists(ctx, IncrSnapKey("t", 200, 210))
+	require.NoError(t, err)
+	assert.True(t, ok, "active incr 200→210 should survive")
+}
+
+// TestGC_MultipleTablesGCedIndependently verifies that GC operates correctly
+// when the bucket contains artefacts for several tables.
+func TestGC_MultipleTablesGCedIndependently(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	recent := time.Now().UTC()
+
+	// t1: old full at 10, old incr 10→20, newer full at 100
+	// → the incr (base=10 < 100) qualifies for deletion.
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t1", 10, 1, old)
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t1", 100, 0, old) // second full makes incr stale
+
+	// t2: single recent full (should survive unchanged).
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t2", 20, 0, recent)
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour,
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// t1: latest full (100) survives.
+	ok, _ := bucket.Exists(ctx, FullSnapKey("t1", 100))
+	assert.True(t, ok, "t1 latest full should survive")
+
+	// t1: old full (10) is deleted.
+	ok, _ = bucket.Exists(ctx, FullSnapKey("t1", 10))
+	assert.False(t, ok, "t1 old full should be deleted")
+
+	// t1: old incr deleted.
+	ok, _ = bucket.Exists(ctx, IncrSnapKey("t1", 10, 20))
+	assert.False(t, ok, "t1 old incr should be deleted")
+
+	// t2: all artefacts survive.
+	ok, _ = bucket.Exists(ctx, FullSnapKey("t2", 20))
+	assert.True(t, ok, "t2 full should survive")
+}
+
+// TestGC_WithLease verifies that a leased table is entirely skipped by GC.
+func TestGC_WithLease(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	old := time.Now().UTC().Add(-48 * time.Hour)
+
+	setupFullAndIncrArtefacts(t, ctx, bucket, "leased", 100, 2, old)
+
+	// Upload a lease file for this table.
+	require.NoError(t, bucket.Upload(ctx, LeaseKey("leased", "downloader-node"), bytes.NewReader(nil)))
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour,
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// Nothing should have been deleted because the table is leased.
+	ok, _ := bucket.Exists(ctx, IncrSnapKey("leased", 100, 110))
+	assert.True(t, ok, "leased table artefacts must not be deleted")
+}
+
+// TestGC_TombstonesWrittenBeforeDeletion verifies that GC writes tombstone log
+// entries before deleting artefacts.
+func TestGC_TombstonesWrittenBeforeDeletion(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	old := time.Now().UTC().Add(-48 * time.Hour)
+
+	// Single full + one old incremental.
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 100, 1, old)
+	// Add a second full so the first one qualifies for deletion.
+	setupFullAndIncrArtefacts(t, ctx, bucket, "t", 200, 0, old)
+
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour,
+		Interval:  time.Minute,
+	}, newTestLogger())
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// At least one gc/ log entry should have been written.
+	gcLogFound := false
+	err := bucket.Iter(ctx, "gc/", func(name string) error {
+		gcLogFound = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, gcLogFound, "at least one GC tombstone log should be written")
+}
+
+// TestGC_RunLoopStopsOnContextCancel verifies that Run exits when the context
+// is cancelled (smoke test).
+func TestGC_RunLoopStopsOnContextCancel(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	gc := NewGCWorker(GCConfig{
+		Bucket:    bucket,
+		Retention: time.Hour,
+		Interval:  10 * time.Millisecond,
+	}, newTestLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		gc.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("GCWorker.Run did not stop after context cancellation")
+	}
+}

--- a/replication/store/meta.go
+++ b/replication/store/meta.go
@@ -1,0 +1,104 @@
+// Copyright JAMF Software, LLC
+
+// Package store provides shared-storage snapshot export and garbage collection
+// for Armada leader clusters (proposal 005 – Phase A).
+//
+// The package defines the object-key scheme and the JSON commit-signal (Meta) that
+// governs the lifecycle of snapshot artefacts in the configured blob store.
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SnapshotType distinguishes full from incremental snapshot artefacts.
+type SnapshotType string
+
+const (
+	// SnapshotTypeFull denotes a complete table snapshot.
+	SnapshotTypeFull SnapshotType = "full"
+	// SnapshotTypeIncremental denotes a delta snapshot starting from a prior base.
+	SnapshotTypeIncremental SnapshotType = "incr"
+
+	// SnapshotFormat identifies the wire format of inter-cluster snapshot artefacts:
+	// a sequence of length-prefixed, snappy-compressed armadapb.Command protobuf messages.
+	SnapshotFormat = "armada-command-v1"
+)
+
+// Meta is the commit signal written to shared storage after a snapshot artefact has
+// been fully uploaded and its SHA-256 verified. Followers treat the absence of a
+// corresponding .meta file as an incomplete (uncommitted) artefact and ignore the
+// associated .snap file.
+type Meta struct {
+	Table     string       `json:"table"`
+	Type      SnapshotType `json:"type"`
+	BaseIndex uint64       `json:"base_index"`
+	TipIndex  uint64       `json:"tip_index"`
+	SizeBytes int64        `json:"size_bytes"`
+	SHA256    string       `json:"sha256"`
+	CreatedAt time.Time    `json:"created_at"`
+	NodeID    string       `json:"node_id"`
+	Format    string       `json:"format"`
+}
+
+// Object key helpers ─────────────────────────────────────────────────────────
+
+// FullSnapKey returns the object key for a full snapshot artefact.
+//
+//	snapshots/{table}/full/{tip_index}.snap
+func FullSnapKey(tableName string, tipIndex uint64) string {
+	return fmt.Sprintf("snapshots/%s/full/%d.snap", tableName, tipIndex)
+}
+
+// FullMetaKey returns the object key for a full snapshot meta commit file.
+//
+//	snapshots/{table}/full/{tip_index}.snap.meta
+func FullMetaKey(tableName string, tipIndex uint64) string {
+	return FullSnapKey(tableName, tipIndex) + ".meta"
+}
+
+// IncrSnapKey returns the object key for an incremental snapshot artefact.
+//
+//	snapshots/{table}/incr/{base_index}_{tip_index}.snap
+func IncrSnapKey(tableName string, baseIndex, tipIndex uint64) string {
+	return fmt.Sprintf("snapshots/%s/incr/%d_%d.snap", tableName, baseIndex, tipIndex)
+}
+
+// IncrMetaKey returns the object key for an incremental snapshot meta commit file.
+//
+//	snapshots/{table}/incr/{base_index}_{tip_index}.snap.meta
+func IncrMetaKey(tableName string, baseIndex, tipIndex uint64) string {
+	return IncrSnapKey(tableName, baseIndex, tipIndex) + ".meta"
+}
+
+// LeaseKey returns the object key for a downloader lease file. Lease files
+// prevent GC from deleting an artefact that is currently being downloaded.
+//
+//	snapshots/{table}/.lease/{node_id}
+func LeaseKey(tableName, nodeID string) string {
+	return fmt.Sprintf("snapshots/%s/.lease/%s", tableName, nodeID)
+}
+
+// GCLogKey returns the object key for a GC tombstone audit-log entry.
+//
+//	gc/{timestamp}.log
+func GCLogKey(t time.Time) string {
+	return fmt.Sprintf("gc/%s.log", t.UTC().Format(time.RFC3339Nano))
+}
+
+// Meta marshaling helpers ─────────────────────────────────────────────────────
+
+func (m Meta) String() string {
+	return fmt.Sprintf("Meta{table=%s, type=%s, base=%d, tip=%d, size=%d, sha256=%s, created_at=%s, node_id=%s, format=%s}",
+		m.Table, m.Type, m.BaseIndex, m.TipIndex, m.SizeBytes, m.SHA256, m.CreatedAt.Format(time.RFC3339), m.NodeID, m.Format)
+}
+
+func marshalMeta(m Meta) ([]byte, error) {
+	return json.Marshal(m)
+}
+
+func unmarshalMeta(data []byte, m *Meta) error {
+	return json.Unmarshal(data, m)
+}

--- a/storage/table/manager.go
+++ b/storage/table/manager.go
@@ -339,8 +339,6 @@ func (m *Manager) cleanupLoop() {
 }
 
 func (m *Manager) cleanup() error {
-	ctx, cancel := context.WithTimeout(context.Background(), m.cleanupTimeout)
-	defer cancel()
 	ls, err := m.store.GetAll(fmt.Sprintf("/cleanup/%d/*", m.cfg.NodeID))
 	if err != nil {
 		return err
@@ -357,7 +355,7 @@ func (m *Manager) cleanup() error {
 				return m.store.Delete(l.Key, l.Ver)
 			}
 
-			if err := m.nh.SyncRemoveData(ctx, c.ClusterID, m.cfg.NodeID); err != nil {
+			if err := m.nh.RemoveData(c.ClusterID, m.cfg.NodeID); err != nil {
 				return err
 			}
 			if err := m.cfg.Table.FS.RemoveAll(c.SMDataPath); err != nil {

--- a/storage/table/manager_test.go
+++ b/storage/table/manager_test.go
@@ -17,10 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var minimalTestConfig = func() Config {
+func minimalTestConfig(t *testing.T) Config {
+	t.Helper()
 	return Config{
 		NodeID: 1,
-		Table:  TableConfig{HeartbeatRTT: 1, ElectionRTT: 5, FS: pvfs.NewMem(), BlockCacheSize: 1024, TableCacheSize: 1024},
+		Table:  TableConfig{HeartbeatRTT: 1, ElectionRTT: 5, FS: pvfs.Default, BlockCacheSize: 1024, TableCacheSize: 1024, DataDir: t.TempDir() + "/data"},
 		Meta:   MetaConfig{HeartbeatRTT: 1, ElectionRTT: 5},
 	}
 }
@@ -31,7 +32,7 @@ func TestManager_CreateTable(t *testing.T) {
 	node, m := startRaftNode(t)
 	defer node.Close()
 
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.Start()
 	defer tm.Close()
 
@@ -60,7 +61,7 @@ func TestManager_DeleteTable(t *testing.T) {
 	node, m := startRaftNode(t)
 	defer node.Close()
 
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.cleanupGracePeriod = 0
 	tm.Start()
 	defer tm.Close()
@@ -93,7 +94,7 @@ func TestManager_DeleteTable(t *testing.T) {
 	r.ErrorIs(err, raft.ErrLogDBNotCreatedOrClosed)
 
 	// FS cleaned
-	files, err := tm.cfg.Table.FS.List("")
+	files, err := tm.cfg.Table.FS.List(tm.cfg.Table.DataDir)
 	r.NoError(err)
 	r.Len(files, 1, "FS should contain only a root directory (named after hostname)")
 }
@@ -120,7 +121,7 @@ func TestManager_LeaseTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.Start()
 	defer tm.Close()
 	_, err := tm.CreateTable(existingTable)
@@ -164,7 +165,7 @@ func TestManager_ReturnTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.Start()
 	defer tm.Close()
 	_, err := tm.CreateTable(existingTable)
@@ -210,7 +211,7 @@ func TestManager_GetTable(t *testing.T) {
 
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.Start()
 	defer tm.Close()
 	_, err := tm.CreateTable(existingTable)
@@ -234,7 +235,7 @@ func TestManager_Restore(t *testing.T) {
 	const existingTable = "existingTable"
 	node, m := startRaftNode(t)
 	defer node.Close()
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.Start()
 	defer tm.Close()
 	_, err := tm.CreateTable(existingTable)
@@ -260,7 +261,7 @@ func TestManager_reconcile(t *testing.T) {
 	defer node.Close()
 
 	const reconcileInterval = 1 * time.Second
-	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig())
+	tm := NewManager(node, m, &kv.MapStore{}, minimalTestConfig(t))
 	tm.reconcileInterval = reconcileInterval
 
 	tm.Start()


### PR DESCRIPTION
This pull request introduces a leader-side shared snapshot export and garbage collection (GC) feature (proposal 005), allowing the leader to periodically export table snapshots to a shared object store (currently supporting the filesystem backend). It adds configuration flags, integrates snapshot export and GC workers into the leader process, and provides supporting code and tests. The CLI documentation and dependencies are also updated.

**New snapshot export and GC feature:**

- Added a new set of CLI flags for configuring leader-side snapshot export to a shared blob store, including backend type, configuration, export intervals, retention, and GC schedule (`cmd/flags.go`, `docs/operations_guide/cli/armada_leader.md`). [[1]](diffhunk://#diff-e231d920accff9e68d1581fc082513cda53631f2a312c9005448288b29dd08a3R130-R147) [[2]](diffhunk://#diff-c158763735a0a272c9240f1656fbc844e79de531c73699d03958fba8709715fcR96-R104)
- Integrated snapshot exporter and GC worker into the leader process, starting them when a non-"none" backend is configured (`cmd/leader.go`). [[1]](diffhunk://#diff-4176b1e69e7daff9d5b3f86c7c6e2ad2984e2ad82e58a2ac52c33e23c8f72028R121-R143) [[2]](diffhunk://#diff-4176b1e69e7daff9d5b3f86c7c6e2ad2984e2ad82e58a2ac52c33e23c8f72028R36)
- Implemented helper functions for snapshot bucket creation and configuration mapping, with unit tests (`cmd/snapshot.go`, `cmd/snapshot_test.go`). [[1]](diffhunk://#diff-d3f8c68b6835fab1d4e036e013de3df871df2967adb23e72b5483668bd7e9c50R1-R50) [[2]](diffhunk://#diff-dbc2677449321a36c4898a35f071cee4ce8889e67ade09881eca95619c80df14R1-R74)

**Snapshot GC logic:**

- Added `replication/store/gc.go`, which implements the `GCWorker` responsible for periodically removing expired snapshot artefacts from the shared store, ensuring retention of the most recent snapshots and respecting downloader leases (`replication/store/gc.go`).

**Dependency updates:**

- Added `github.com/thanos-io/objstore` and related dependencies to `go.mod` for object storage support. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R33) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R68-R73) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R130)

**Other minor changes:**

- Set `DisableWAL: true` in `pebble/pebble.go` options for improved performance in the default configuration.