### PR TITLE
feat: add GitHub Actions workflow for Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,22 @@
+name: "Copilot Setup Steps"
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file to set up Copilot-related steps. The workflow is specifically configured to trigger on changes to itself and ensures the environment is prepared for Copilot jobs.

**New Copilot setup workflow:**

* Added `.github/workflows/copilot-setup-steps.yml` to define a reusable workflow for Copilot setup, including code checkout and Go installation steps.