### PR TITLE
fix: binary release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   release-binary:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
     strategy:
       matrix:
         goos: [linux, darwin]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to add permissions for package and content writing to the `release-binary` job. This ensures the workflow has the necessary access to publish binaries and modify repository contents.

Workflow permissions:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16-R18): Added `packages: write` and `contents: write` permissions to the `release-binary` job to enable publishing and repository updates.